### PR TITLE
[#13] 소셜 가입 및 로그인 기능을 제외한 authenticate 통합 모듈을 개발한다.

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -7,8 +7,8 @@ module.exports = {
       watch: false,
       merge_logs: false,
       log_date_format: 'YYYY-MM-DD HH:mm Z',
-      // out_file: '/home/ubuntu/.pm2/logs/api-access.log', #
-      // error_file: '/home/ubuntu/.pm2/logs/api-error.log', #
+      // out_file: '/home/ubuntu/.pm2/logs/api-access.log',
+      // error_file: '/home/ubuntu/.pm2/logs/api-error.log',
       autorestart: true,
       exec_mode: 'cluster',
       env: {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@types/hpp": "^0.2.6",
     "@types/jest": "^29.5.2",
     "@types/node": "^20.3.1",
+    "@types/passport": "^1.0.17",
     "@types/supertest": "^6.0.0",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       '@types/node':
         specifier: ^20.3.1
         version: 20.16.10
+      '@types/passport':
+        specifier: ^1.0.17
+        version: 1.0.17
       '@types/supertest':
         specifier: ^6.0.0
         version: 6.0.2
@@ -757,6 +760,9 @@ packages:
 
   '@types/node@20.16.10':
     resolution: {integrity: sha512-vQUKgWTjEIRFCvK6CyriPH3MZYiYlNy0fKiEYHWbcoWLEgs4opurGGKlebrTLqdSMIbXImH6XExNiIyNUv3WpA==}
+
+  '@types/passport@1.0.17':
+    resolution: {integrity: sha512-aciLyx+wDwT2t2/kJGJR2AEeBz0nJU4WuRX04Wu9Dqc5lSUtwu0WERPHYsLhF9PtseiAMPBGNUOtFjxZ56prsg==}
 
   '@types/qs@6.9.16':
     resolution: {integrity: sha512-7i+zxXdPD0T4cKDuxCUXJ4wHcsJLwENa6Z3dCu8cfCK743OGy5Nu1RmAGqDPsoTDINVEcdXKRvR/zre+P2Ku1A==}
@@ -4233,6 +4239,10 @@ snapshots:
   '@types/node@20.16.10':
     dependencies:
       undici-types: 6.19.8
+
+  '@types/passport@1.0.17':
+    dependencies:
+      '@types/express': 4.17.21
 
   '@types/qs@6.9.16': {}
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module, NestModule, RequestMethod } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { ConfigModule } from '@nestjs/config';
@@ -7,6 +7,7 @@ import { OrmConfig } from './common/database/orm-config';
 import { DataSource, DataSourceOptions } from 'typeorm';
 import { UserModule } from './domains/user/user.module';
 import { AuthModule } from './domains/auth/auth.module';
+import { BearerAccessTokenMiddleware } from './domains/auth/middlewares/bearer-access-token.middleware';
 
 @Module({
   imports: [
@@ -26,4 +27,20 @@ import { AuthModule } from './domains/auth/auth.module';
   controllers: [AppController],
   providers: [AppService],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer
+      .apply(BearerAccessTokenMiddleware)
+      .exclude(
+        {
+          path: 'auth/social-login',
+          method: RequestMethod.POST,
+        },
+        {
+          path: 'auth/token/access',
+          method: RequestMethod.POST,
+        },
+      )
+      .forRoutes('*');
+  }
+}

--- a/src/common/database/base.repository.ts
+++ b/src/common/database/base.repository.ts
@@ -1,0 +1,14 @@
+import { DataSource, EntityManager, QueryRunner, Repository } from 'typeorm';
+
+export class BaseCommonRepository<T> extends Repository<T> {
+  constructor(
+    private readonly dataSource: DataSource,
+    entity: any,
+  ) {
+    super(entity, dataSource.createEntityManager());
+  }
+
+  protected getManager(qr?: QueryRunner): EntityManager {
+    return qr ? qr.manager : this.dataSource.manager;
+  }
+}

--- a/src/common/decorators/transaction-manager.decorator.ts
+++ b/src/common/decorators/transaction-manager.decorator.ts
@@ -1,0 +1,7 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+/**Custom Transaction Manager*/
+export const TransactionManger = createParamDecorator((data: unknown, ctx: ExecutionContext) => {
+  const req = ctx.switchToHttp().getRequest();
+  return req.queryRunnerManager;
+});

--- a/src/common/entities/base.entity.ts
+++ b/src/common/entities/base.entity.ts
@@ -1,4 +1,4 @@
-import { CreateDateColumn, DeleteDateColumn, UpdateDateColumn, VersionColumn } from 'typeorm';
+import { CreateDateColumn, UpdateDateColumn, VersionColumn } from 'typeorm';
 import { Exclude } from 'class-transformer';
 
 export abstract class BaseModel {
@@ -9,10 +9,6 @@ export abstract class BaseModel {
   @UpdateDateColumn()
   @Exclude()
   updatedAt: Date;
-
-  @DeleteDateColumn({ default: null })
-  @Exclude()
-  deletedAt: Date | null;
 
   @VersionColumn()
   version: number;

--- a/src/common/entities/base.entity.ts
+++ b/src/common/entities/base.entity.ts
@@ -11,6 +11,7 @@ export abstract class BaseModel {
   updatedAt: Date;
 
   @DeleteDateColumn({ default: null })
+  @Exclude()
   deletedAt: Date | null;
 
   @VersionColumn()

--- a/src/common/interceptor/transaction.interceptor.ts
+++ b/src/common/interceptor/transaction.interceptor.ts
@@ -1,0 +1,46 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  HttpException,
+  Injectable,
+  InternalServerErrorException,
+  NestInterceptor,
+} from '@nestjs/common';
+import { DataSource, QueryRunner } from 'typeorm';
+import { catchError, Observable, tap } from 'rxjs';
+import { HttpErrorConstants } from 'src/core/http/http-error-objects';
+
+@Injectable()
+export class TransactionInterceptor implements NestInterceptor {
+  constructor(private readonly dataSource: DataSource) {}
+  async intercept(context: ExecutionContext, next: CallHandler): Promise<Observable<any>> {
+    const req = context.switchToHttp().getRequest();
+
+    const qr: QueryRunner = this.dataSource.createQueryRunner();
+
+    await qr.connect();
+    await qr.startTransaction();
+
+    req.queryRunner = qr;
+
+    return next.handle().pipe(
+      catchError(async (e) => {
+        await qr.rollbackTransaction();
+        await qr.release();
+        console.error('e ->', e);
+        // Todo:// 비즈니스 로직에서 임의로 Throw Exception 시킨 정보를 별도로 처리 가능한지 테스트
+        if (e instanceof HttpException) {
+          console.error(`error message -> ${e.message}, error status -> ${e.getStatus()}`);
+          throw new InternalServerErrorException(HttpErrorConstants.INTERNAL_DATABASE_ERROR);
+        } else {
+          throw new InternalServerErrorException(HttpErrorConstants.INTERNAL_SERVER_ERROR);
+        }
+      }),
+      tap(async () => {
+        console.log('start Transaction');
+        await qr.commitTransaction();
+        await qr.release();
+      }),
+    );
+  }
+}

--- a/src/core/http/http-error-objects.ts
+++ b/src/core/http/http-error-objects.ts
@@ -76,7 +76,7 @@ export const HttpErrorConstants = {
 
   INVALID_TOKEN: {
     error: 'UNAUTHORIZED',
-    message: '잘못된 토큰값 입니다.',
+    message: '토큰 검증 실패',
   } as HttpErrorFormat,
 
   CANNOT_FIND_USER: {
@@ -126,7 +126,7 @@ export const HttpErrorConstants = {
 
   NOT_FOUND_USER: {
     error: 'NOT_FOUND_USER',
-    message: '토큰에 지정된 유저가 존재하지 않습니다.',
+    message: '사용자를 찾을수 없습니다.',
   } as HttpErrorFormat,
 
   NOT_REGISTER_USER: {

--- a/src/core/http/http-error-objects.ts
+++ b/src/core/http/http-error-objects.ts
@@ -36,22 +36,7 @@ export const HttpErrorConstants = {
 
   EXIST_EMAIL: {
     error: 'EXIST_EMAIL',
-    message: '이미 가입된 이메일 정보가 존재해요.',
-  } as HttpErrorFormat,
-
-  EXIST_DATA: {
-    error: 'EXIST_DATA',
-    message: '해당 정보가 이미 존재합니다.',
-  } as HttpErrorFormat,
-
-  FILE_SIZE_LIMIT_EXCEEDED: {
-    error: 'FILE_SIZE_LIMIT_EXCEEDED',
-    message: '업로드 하는 파일의 사이즈가 너무 큽니다.',
-  } as HttpErrorFormat,
-
-  INVALID_FILE_TYPE: {
-    error: 'INVALID_FILE_TYPE',
-    message: '파일의 규격이 다릅니다.',
+    message: '이미 가입된 이메일 정보가 존재합니다.',
   } as HttpErrorFormat,
 
   VALIDATE_ERROR: {
@@ -69,19 +54,14 @@ export const HttpErrorConstants = {
     message: '이메일 또는 비밀번호가 올바르지 않습니다.',
   } as HttpErrorFormat,
 
-  INVALID_PASSWORD: {
-    error: 'INVALID_PASSWORD',
-    message: '비밀번호가 올바르지 않습니다. ',
-  } as HttpErrorFormat,
-
   INVALID_TOKEN: {
-    error: 'UNAUTHORIZED',
+    error: 'INVALID_TOKEN',
     message: '토큰 검증 실패',
   } as HttpErrorFormat,
 
-  CANNOT_FIND_USER: {
-    error: 'CANNOT_FIND_USER',
-    message: '유저를 찾을 수 없습니다.',
+  INVALID_TOKEN_FORMAT: {
+    error: 'INVALID_TOKEN_FORMAT',
+    message: '토큰 포맷이 일치하지 않습니다.',
   } as HttpErrorFormat,
 
   EXPIRED_ACCESS_TOKEN: {
@@ -99,8 +79,8 @@ export const HttpErrorConstants = {
     message: '토큰이 만료되었습니다.',
   } as HttpErrorFormat,
 
-  FORBIDDEN_TOKEN: {
-    error: 'FORBIDDEN_TOKEN',
+  UNAUTHORIZED_INVALIE_SIGNATURE: {
+    error: 'UNAUTHORIZED_INVALIE',
     message: '토큰의 시그니처가 불일치 합니다.',
   } as HttpErrorFormat,
 
@@ -111,7 +91,7 @@ export const HttpErrorConstants = {
 
   INVALID_BEARER_TOKEN: {
     error: 'INVALID_BEARER_TOKEN',
-    message: '토큰의 타입이 Bearer 유형이 아닙니다.',
+    message: '잘못된 토큰 타입입니다.',
   } as HttpErrorFormat,
 
   NOT_COLLETED_ACCESS_TYPE: {
@@ -133,4 +113,14 @@ export const HttpErrorConstants = {
     error: 'NOT_REGISTER_USER',
     message: '가입된 유저가 아닙니다.',
   } as HttpErrorFormat,
+
+  COMMON_UNAUTHORIZED_TOKEN_ERROR: [] as HttpErrorFormat[], // 공통(Beaer Access Token Error Template)
 };
+
+HttpErrorConstants.COMMON_UNAUTHORIZED_TOKEN_ERROR = [
+  HttpErrorConstants.UNAUTHORIZED,
+  HttpErrorConstants.NOT_FOUND_TOKEN,
+  HttpErrorConstants.INVALID_TOKEN,
+  HttpErrorConstants.EXPIRED_TOKEN,
+  HttpErrorConstants.UNAUTHORIZED_INVALIE_SIGNATURE,
+];

--- a/src/core/http/http-error-objects.ts
+++ b/src/core/http/http-error-objects.ts
@@ -118,9 +118,9 @@ export const HttpErrorConstants = {
 };
 
 HttpErrorConstants.COMMON_UNAUTHORIZED_TOKEN_ERROR = [
-  HttpErrorConstants.UNAUTHORIZED,
   HttpErrorConstants.NOT_FOUND_TOKEN,
   HttpErrorConstants.INVALID_TOKEN,
   HttpErrorConstants.EXPIRED_TOKEN,
+  HttpErrorConstants.INVALID_TOKEN_FORMAT,
   HttpErrorConstants.UNAUTHORIZED_INVALIE_SIGNATURE,
 ];

--- a/src/core/http/http-error-objects.ts
+++ b/src/core/http/http-error-objects.ts
@@ -29,6 +29,11 @@ export const HttpErrorConstants = {
     message: '알 수 없는 오류가 발생하였습니다.',
   } as HttpErrorFormat,
 
+  INTERNAL_DATABASE_ERROR: {
+    error: 'INTERNAL_DATABASE_ERROR',
+    message: '트랜잭션 수행중 에러가 발생하였습니다.',
+  } as HttpErrorFormat,
+
   EXIST_INFO: {
     error: 'EXIST_INFO',
     message: '가입된 정보가 존재합니다.',

--- a/src/core/http/http-response.ts
+++ b/src/core/http/http-response.ts
@@ -21,7 +21,7 @@ export default class HttpResponse {
   }
 
   static noContent(res: Response): Response<unknown> {
-    return res.status(status.OK).json();
+    return res.status(status.NO_CONTENT).json();
   }
 
   static badRequest<T>(res: Response, object?: T | Error): Response<unknown> {

--- a/src/domains/auth/auth.controller.ts
+++ b/src/domains/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post, Req, Res } from '@nestjs/common';
+import { Body, Controller, Post, Req, Res, Headers } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { ApiTags } from '@nestjs/swagger';
 import { ApiCommonErrorResponseTemplate } from 'src/core/swagger/api-error-common-response';
@@ -22,6 +22,21 @@ export class AuthController {
   async socialLogin(@Req() req: Request, @Res() res: Response, @Body() dto: SocialUserDto) {
     const token = await this.authService.socialLogin(req.get('user-agent').toLowerCase(), dto);
     return HttpResponse.created(res, { body: token });
+  }
+
+  @Post('logout')
+  async logOut(@Res() res: Response) {
+    return HttpResponse.ok(res);
+  }
+
+  /**
+   * Todo:// Guard 모듈 추가
+   * 토큰을 엔드포인트에서 바로 헤더로 받는것이 아니라 Guard or Middleware에서 받아서 처리되도록 핸들링
+   */
+  @Post('token/access')
+  async rotateAccessToken(@Res() res: Response, @Headers('authorization') token: string) {
+    const accessToken = await this.authService.rotateAccessToken(token);
+    return HttpResponse.ok(res, accessToken);
   }
 
   // // 타 인증서버를 거치지 않는 일반 로그인

--- a/src/domains/auth/auth.controller.ts
+++ b/src/domains/auth/auth.controller.ts
@@ -6,7 +6,7 @@ import { ApiCommonErrorResponseTemplate } from 'src/core/swagger/api-error-commo
 import { Response, Request } from 'express';
 import HttpResponse from 'src/core/http/http-response';
 import { SocialUserDto } from '../user/dto/social-user.dto';
-import { SocialLoginDocs } from './swagger/rest-swagger.decorator';
+import { RotateAccessTokenDocs, SocialLoginDocs } from './swagger/rest-swagger.decorator';
 import { RefreshTokenGuard } from './guards/refresh-token.guard';
 import { Authorization } from './deocorators/authorization.decorator';
 
@@ -25,6 +25,7 @@ export class AuthController {
   }
 
   // 토큰 재발급
+  @RotateAccessTokenDocs()
   @UseGuards(RefreshTokenGuard)
   @Post('token/access')
   async rotateAccessToken(@Res() res: Response, @Req() req: Request, @Authorization() token: string) {
@@ -33,8 +34,8 @@ export class AuthController {
     return HttpResponse.created(res, { body: accessToken });
   }
 
-  @Post('logout')
-  async logOut(@Res() res: Response) {
-    return HttpResponse.ok(res);
-  }
+  // @Post('logout')
+  // async logOut(@Res() res: Response) {
+  //   return HttpResponse.ok(res);
+  // }
 }

--- a/src/domains/auth/auth.controller.ts
+++ b/src/domains/auth/auth.controller.ts
@@ -6,7 +6,7 @@ import { ApiCommonErrorResponseTemplate } from 'src/core/swagger/api-error-commo
 import { Response, Request } from 'express';
 import HttpResponse from 'src/core/http/http-response';
 import { SocialUserDto } from '../user/dto/social-user.dto';
-import { RotateAccessTokenDocs, SocialLoginDocs } from './swagger/rest-swagger.decorator';
+import { LogOutDocs, RotateAccessTokenDocs, SocialLoginDocs } from './swagger/rest-swagger.decorator';
 import { RefreshTokenGuard } from './guards/refresh-token.guard';
 import { Authorization } from './deocorators/authorization.decorator';
 
@@ -34,8 +34,12 @@ export class AuthController {
     return HttpResponse.created(res, { body: accessToken });
   }
 
-  // @Post('logout')
-  // async logOut(@Res() res: Response) {
-  //   return HttpResponse.ok(res);
-  // }
+  // 로그아웃
+  @LogOutDocs()
+  @Post('logout')
+  async logOut(@Res() res: Response, @Req() req: Request) {
+    const payload = req.user;
+    await this.authService.removeRefToken(payload);
+    return HttpResponse.noContent(res);
+  }
 }

--- a/src/domains/auth/auth.module.ts
+++ b/src/domains/auth/auth.module.ts
@@ -3,11 +3,14 @@ import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { UserModule } from 'src/domains/user/user.module';
 import { JwtModule } from '@nestjs/jwt';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { RefreshToken } from './entities/refresh-token.entity';
+import { RefreshTokenRepository } from './repositories/refresh-token.repository';
 
 @Module({
-  imports: [JwtModule.register({}), UserModule],
+  imports: [JwtModule.register({}), TypeOrmModule.forFeature([RefreshToken]), UserModule],
   controllers: [AuthController],
-  providers: [AuthService],
+  providers: [AuthService, RefreshTokenRepository],
   exports: [AuthService],
 })
 export class AuthModule {}

--- a/src/domains/auth/auth.module.ts
+++ b/src/domains/auth/auth.module.ts
@@ -11,6 +11,6 @@ import { RefreshTokenRepository } from './repositories/refresh-token.repository'
   imports: [JwtModule.register({}), TypeOrmModule.forFeature([RefreshToken]), UserModule],
   controllers: [AuthController],
   providers: [AuthService, RefreshTokenRepository],
-  exports: [AuthService],
+  exports: [AuthService, JwtModule],
 })
 export class AuthModule {}

--- a/src/domains/auth/auth.service.ts
+++ b/src/domains/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException, UnauthorizedException } from '@nestjs/common';
 import { detectPlatform } from './utils/client.util';
 import { UserRepository } from 'src/domains/user/repositories/user.repository';
 import { JwtService } from '@nestjs/jwt';
@@ -8,6 +8,8 @@ import { User } from 'src/domains/user/entities/user.entity';
 import { SocialUserDto } from '../user/dto/social-user.dto';
 import { LoginResponseDto } from './dtos/login-response.dto';
 import { RefreshTokenRepository } from './repositories/refresh-token.repository';
+import { HttpErrorConstants } from 'src/core/http/http-error-objects';
+import { TokenPayload } from './interfaces/token-payload.interface';
 
 // import { LoginUserDto } from './dtos/login-user.dto';
 // import { HttpErrorConstants } from 'src/core/http/http-error-objects';
@@ -41,6 +43,93 @@ export class AuthService {
   }
 
   /**
+   * Refresh 토큰으로 Access 재발급
+   * @param rawToken
+   * @returns accessToken
+   */
+  async rotateAccessToken(rawToken: string): Promise<string> {
+    const payLoad = await this.parseBearerToken(rawToken, true);
+    const user = await this.userRepository.findOne({
+      where: {
+        id: payLoad.sub,
+      },
+    });
+
+    if (!user) {
+      throw new NotFoundException(HttpErrorConstants.NOT_FOUND_USER);
+    }
+
+    const accessToken = await this.issueToken(user, false);
+
+    return accessToken;
+  }
+
+  /**
+   * 토큰 발행 함수
+   * @param user
+   * @param isRefreshToken  true -> refresh, false -> access
+   */
+  async issueToken(user: User, isRefreshToken: boolean) {
+    const refreshTokenSecret = this.configService.get<string>(ENV_CONFIG.AUTH.REFRESH_SECRET);
+    const accessTokeknSecret = this.configService.get<string>(ENV_CONFIG.AUTH.ACCESS_SECRET);
+
+    const payload = await this.createPayload(user, isRefreshToken);
+
+    return await this.jwtService.signAsync(payload, {
+      secret: isRefreshToken ? refreshTokenSecret : accessTokeknSecret,
+      expiresIn: isRefreshToken
+        ? this.configService.get<string>(ENV_CONFIG.AUTH.EXPOSE_REFRESH_TK)
+        : this.configService.get<string>(ENV_CONFIG.AUTH.EXPOSE_ACCESS_TK),
+    });
+  }
+
+  /**
+   * Bearer 토큰 검증 및 payload 반환 메서드
+   * @param rawToken 토큰
+   * @param isRefreshToken
+   * @returns PayLoad
+   */
+  async parseBearerToken(rawToken: string, isRefreshToken: boolean): Promise<TokenPayload> {
+    const bearerTokenSplit = rawToken.split(' ');
+
+    if (bearerTokenSplit.length !== 2) {
+      throw new BadRequestException(HttpErrorConstants.INVALID_TOKEN);
+    }
+
+    const [bearer, token] = bearerTokenSplit;
+
+    if (bearer.toLowerCase() !== 'bearer') {
+      throw new BadRequestException(HttpErrorConstants.INVALID_TOKEN);
+    }
+
+    const payload = await this.verifyAsyncToken(token, isRefreshToken);
+
+    return payload;
+  }
+
+  /**
+   * AT & RT 토큰 검증 메서드
+   * @param token: Access & Refresh
+   */
+  async verifyAsyncToken(rawToken: string, isRefreshToken: boolean) {
+    try {
+      return await this.jwtService.verifyAsync(rawToken, {
+        secret: isRefreshToken
+          ? this.configService.get<string>(ENV_CONFIG.AUTH.REFRESH_SECRET)
+          : this.configService.get<string>(ENV_CONFIG.AUTH.ACCESS_SECRET),
+      });
+    } catch (error) {
+      console.error('token verify exception error ->', error.name);
+      if (error.name === 'TokenExpiredError') {
+        throw new UnauthorizedException(HttpErrorConstants.EXPIRED_TOKEN);
+      }
+      if (error.name === 'JsonWebTokenError') {
+        throw new UnauthorizedException(HttpErrorConstants.INVALID_TOKEN);
+      }
+    }
+  }
+
+  /**
    * access & refresh Token 발행 메서드
    * @param user
    */
@@ -54,69 +143,15 @@ export class AuthService {
   }
 
   /**
-   * 토큰 발행 함수
+   * 토큰 페이로드 생성 메서드
    * @param user
-   * @param isRefreshToken  true -> refresh, false -> access
+   * @param isRefreshToken
+   * @returns TokenPayload
    */
-  async issueToken(user: User, isRefreshToken: boolean) {
-    const refreshTokenSecret = this.configService.get<string>(ENV_CONFIG.AUTH.REFRESH_SECRET);
-    const accessTokeknSecret = this.configService.get<string>(ENV_CONFIG.AUTH.ACCESS_SECRET);
-
-    return await this.jwtService.signAsync(
-      {
-        sub: user.id,
-        type: isRefreshToken ? 'rt' : 'at',
-      },
-      {
-        secret: isRefreshToken ? refreshTokenSecret : accessTokeknSecret,
-        expiresIn: isRefreshToken
-          ? this.configService.get<string>(ENV_CONFIG.AUTH.EXPOSE_REFRESH_TK)
-          : this.configService.get<string>(ENV_CONFIG.AUTH.EXPOSE_ACCESS_TK),
-      },
-    );
+  private async createPayload(user: User, isRefreshToken: boolean): Promise<TokenPayload> {
+    if (isRefreshToken) {
+      return { sub: user.id }; // 최소 정보만 포함
+    }
+    return { sub: user.id, email: user.email, name: user.userName }; // 추가 정보 포함
   }
-
-  // /**
-  //  * 로그인시 유저의 이메일과 패스워드 검증
-  //  * @param email
-  //  * @param password
-  //  * @returns User
-  //  */
-  // async authenticate(email: string, password: string): Promise<User> {
-  //   const user = await this.userRepository.findOne({
-  //     where: {
-  //       email: email,
-  //     },
-  //   });
-
-  //   if (!user) {
-  //     throw new UnauthorizedException(HttpErrorConstants.UNAUTHORIZED_USER);
-  //   }
-
-  //   const passOk = await validatedPassword(password, user.password);
-
-  //   if (!passOk) {
-  //     throw new UnauthorizedException(HttpErrorConstants.UNAUTHORIZED_USER);
-  //   }
-
-  //   return user;
-  // }
-
-  /**
-   * @param userAgent
-   * @param dto LoginUserDto
-   * @returns Login Info
-   */
-  // async login(userAgent: string, dto: LoginUserDto) {
-  //   // 유저 Agent detect
-  //   const agent = detectPlatform(userAgent);
-  //   console.log('agent ->', agent);
-
-  //   const user = await this.authenticate(dto.email, dto.password);
-
-  //   return {
-  //     refreshToken: await this.issueToken(user, true),
-  //     accessToken: await this.issueToken(user, false),
-  //   };
-  // }
 }

--- a/src/domains/auth/auth.service.ts
+++ b/src/domains/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable, NotFoundException, UnauthorizedException } from '@nestjs/common';
+import { Injectable, NotFoundException, UnauthorizedException } from '@nestjs/common';
 import { detectPlatform } from './utils/client.util';
 import { UserRepository } from 'src/domains/user/repositories/user.repository';
 import { JwtService } from '@nestjs/jwt';
@@ -94,13 +94,13 @@ export class AuthService {
     const bearerTokenSplit = rawToken.split(' ');
 
     if (bearerTokenSplit.length !== 2) {
-      throw new BadRequestException(HttpErrorConstants.INVALID_TOKEN);
+      throw new UnauthorizedException(HttpErrorConstants.INVALID_TOKEN_FORMAT);
     }
 
     const [bearer, token] = bearerTokenSplit;
 
     if (bearer.toLowerCase() !== 'bearer') {
-      throw new BadRequestException(HttpErrorConstants.INVALID_TOKEN);
+      throw new UnauthorizedException(HttpErrorConstants.INVALID_BEARER_TOKEN);
     }
 
     return token;
@@ -136,7 +136,7 @@ export class AuthService {
       }
       if (error.name === 'JsonWebTokenError') {
         // signature 불일치
-        throw new UnauthorizedException(HttpErrorConstants.INVALID_TOKEN);
+        throw new UnauthorizedException(HttpErrorConstants.UNAUTHORIZED_INVALIE_SIGNATURE);
       }
     }
   }

--- a/src/domains/auth/auth.service.ts
+++ b/src/domains/auth/auth.service.ts
@@ -11,6 +11,7 @@ import { RefreshTokenRepository } from './repositories/refresh-token.repository'
 import { HttpErrorConstants } from 'src/core/http/http-error-objects';
 import { TokenPayLoad } from './interfaces/token-payload.interface';
 import { RefreshToken } from './entities/refresh-token.entity';
+import { DeleteResult } from 'typeorm';
 
 @Injectable()
 export class AuthService {
@@ -138,6 +139,17 @@ export class AuthService {
         throw new UnauthorizedException(HttpErrorConstants.INVALID_TOKEN);
       }
     }
+  }
+
+  /**
+   * refToken을 제거
+   * @param payLoad
+   * @returns
+   */
+  async removeRefToken(payLoad: TokenPayLoad): Promise<DeleteResult> {
+    return this.refreshTokenRepository.delete({
+      user: { id: payLoad.sub },
+    });
   }
 
   /**

--- a/src/domains/auth/consts/platform.const.ts
+++ b/src/domains/auth/consts/platform.const.ts
@@ -1,4 +1,5 @@
 /** user-agent 타입을 체크하기 위한 상수 객체 */
+
 export const PlatFormType = Object.freeze({
   WEB: 'web',
   IOS: 'ios',
@@ -7,3 +8,11 @@ export const PlatFormType = Object.freeze({
 } as const);
 
 type PlatFormType = (typeof PlatFormType)[keyof typeof PlatFormType];
+
+/**DB field 값에서 사용되는 ENUM 상수 객체*/
+export enum PlatFormEnumType {
+  WEB = 'web',
+  IOS = 'ios',
+  ANDROID = 'android',
+  UNKONWN = 'unknown',
+}

--- a/src/domains/auth/deocorators/authorization.decorator.ts
+++ b/src/domains/auth/deocorators/authorization.decorator.ts
@@ -1,0 +1,7 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const Authorization = createParamDecorator((data: any, context: ExecutionContext) => {
+  const req = context.switchToHttp().getRequest();
+
+  return req.headers['authorization'];
+});

--- a/src/domains/auth/dtos/login-response.dto.ts
+++ b/src/domains/auth/dtos/login-response.dto.ts
@@ -14,3 +14,11 @@ export class LoginResponseDto {
   })
   refreshToken: string;
 }
+
+export class RotateAccessTokenDto {
+  @ApiProperty({
+    description: 'accessToken',
+    example: 'eInR59.eyJiJhdCIsImlhdCI6MTc.37gbkd4jAx123c',
+  })
+  accessToken: string;
+}

--- a/src/domains/auth/entities/refresh-token.entity.ts
+++ b/src/domains/auth/entities/refresh-token.entity.ts
@@ -1,0 +1,29 @@
+import { BaseModel } from 'src/common/entities/base.entity';
+import { User } from 'src/domains/user/entities/user.entity';
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { PlatFormEnumType } from '../consts/platform.const';
+
+@Entity()
+export class RefreshToken extends BaseModel {
+  @PrimaryGeneratedColumn({
+    comment: 'PK',
+    type: 'integer',
+    unsigned: true,
+  })
+  id: number;
+
+  @Column({
+    type: 'varchar',
+  })
+  refToken: string;
+
+  @Column({
+    type: 'enum',
+    enum: Object.values(PlatFormEnumType),
+  })
+  platForm: PlatFormEnumType;
+
+  @ManyToOne(() => User, (user) => user.refToken, { onDelete: 'CASCADE' })
+  @JoinColumn()
+  user: User;
+}

--- a/src/domains/auth/guards/refresh-token.guard.ts
+++ b/src/domains/auth/guards/refresh-token.guard.ts
@@ -1,0 +1,27 @@
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import { HttpErrorConstants } from 'src/core/http/http-error-objects';
+import { AuthService } from '../auth.service';
+
+@Injectable()
+export class RefreshTokenGuard implements CanActivate {
+  constructor(private readonly authService: AuthService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req = context.switchToHttp().getRequest();
+
+    const bearerRefreshToken = await req.headers['authorization'];
+
+    if (!bearerRefreshToken) {
+      throw new UnauthorizedException(HttpErrorConstants.NOT_FOUND_TOKEN);
+    }
+    // 토큰 유효성 검사
+    const token = await this.authService.validateBearerToken(bearerRefreshToken);
+    // payLoad
+    const payLoad = await this.authService.parseBearerToken(token, true);
+
+    // req 객체에 본문을 포함해서 리턴
+    req.user = payLoad;
+
+    return true;
+  }
+}

--- a/src/domains/auth/interfaces/token-payload.interface.ts
+++ b/src/domains/auth/interfaces/token-payload.interface.ts
@@ -1,5 +1,5 @@
-export interface TokenPayload {
-  sub: number;
+export interface TokenPayLoad {
+  sub?: number;
   email?: string;
   name?: string;
   role?: string;

--- a/src/domains/auth/interfaces/token-payload.interface.ts
+++ b/src/domains/auth/interfaces/token-payload.interface.ts
@@ -1,0 +1,6 @@
+export interface TokenPayload {
+  sub: number;
+  email?: string;
+  name?: string;
+  role?: string;
+}

--- a/src/domains/auth/middlewares/bearer-access-token.middleware.ts
+++ b/src/domains/auth/middlewares/bearer-access-token.middleware.ts
@@ -1,0 +1,77 @@
+import { BadRequestException, Injectable, NestMiddleware, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import { NextFunction, Request, Response } from 'express';
+import { ENV_CONFIG } from 'src/common/const/env-keys.const';
+import { HttpErrorConstants } from 'src/core/http/http-error-objects';
+
+@Injectable()
+export class BearerAccessTokenMiddleware implements NestMiddleware {
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  async use(req: Request, res: Response, next: NextFunction) {
+    // 헤더값 추출
+    const authHeader = req.headers['authorization'];
+    if (!authHeader) {
+      throw new UnauthorizedException(HttpErrorConstants.NOT_FOUND_TOKEN);
+    }
+
+    const bearerTokenSplit = authHeader.split(' ');
+
+    if (bearerTokenSplit.length !== 2) {
+      throw new BadRequestException(HttpErrorConstants.INVALID_TOKEN);
+    }
+
+    const [bearer, token] = bearerTokenSplit;
+
+    if (bearer.toLowerCase() !== 'bearer') {
+      throw new BadRequestException(HttpErrorConstants.INVALID_TOKEN);
+    }
+
+    try {
+      const payload = await this.jwtService.verifyAsync(token, {
+        secret: this.configService.get<string>(ENV_CONFIG.AUTH.ACCESS_SECRET),
+      });
+
+      req.user = payload;
+
+      next();
+    } catch (error) {
+      console.error('token verify exception error ->', error.name);
+      if (error.name === 'TokenExpiredError') {
+        // 토큰 만료 -> 재로그인 or 발급
+        throw new UnauthorizedException(HttpErrorConstants.EXPIRED_TOKEN);
+      }
+      if (error.name === 'JsonWebTokenError') {
+        // signature 불일치
+        throw new UnauthorizedException(HttpErrorConstants.INVALID_TOKEN);
+      }
+      next();
+    }
+  }
+
+  /**
+   * AT 토큰 검증 메서드
+   * @param rawToken  AccessToken
+   */
+  async verifyAccessToken(accessToken: string) {
+    try {
+      return await this.jwtService.verifyAsync(accessToken, {
+        secret: this.configService.get<string>(ENV_CONFIG.AUTH.ACCESS_SECRET),
+      });
+    } catch (error) {
+      console.error('token verify exception error ->', error.name);
+      if (error.name === 'TokenExpiredError') {
+        // 토큰 만료 -> 재로그인 or 발급
+        throw new UnauthorizedException(HttpErrorConstants.EXPIRED_TOKEN);
+      }
+      if (error.name === 'JsonWebTokenError') {
+        // signature 불일치
+        throw new UnauthorizedException(HttpErrorConstants.INVALID_TOKEN);
+      }
+    }
+  }
+}

--- a/src/domains/auth/middlewares/bearer-access-token.middleware.ts
+++ b/src/domains/auth/middlewares/bearer-access-token.middleware.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable, NestMiddleware, UnauthorizedException } from '@nestjs/common';
+import { Injectable, NestMiddleware, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import { NextFunction, Request, Response } from 'express';
@@ -22,13 +22,13 @@ export class BearerAccessTokenMiddleware implements NestMiddleware {
     const bearerTokenSplit = authHeader.split(' ');
 
     if (bearerTokenSplit.length !== 2) {
-      throw new BadRequestException(HttpErrorConstants.INVALID_TOKEN);
+      throw new UnauthorizedException(HttpErrorConstants.INVALID_TOKEN_FORMAT);
     }
 
     const [bearer, token] = bearerTokenSplit;
 
     if (bearer.toLowerCase() !== 'bearer') {
-      throw new BadRequestException(HttpErrorConstants.INVALID_TOKEN);
+      throw new UnauthorizedException(HttpErrorConstants.INVALID_BEARER_TOKEN);
     }
 
     try {
@@ -47,7 +47,7 @@ export class BearerAccessTokenMiddleware implements NestMiddleware {
       }
       if (error.name === 'JsonWebTokenError') {
         // signature 불일치
-        throw new UnauthorizedException(HttpErrorConstants.INVALID_TOKEN);
+        throw new UnauthorizedException(HttpErrorConstants.UNAUTHORIZED_INVALIE_SIGNATURE);
       }
       next();
     }
@@ -70,7 +70,7 @@ export class BearerAccessTokenMiddleware implements NestMiddleware {
       }
       if (error.name === 'JsonWebTokenError') {
         // signature 불일치
-        throw new UnauthorizedException(HttpErrorConstants.INVALID_TOKEN);
+        throw new UnauthorizedException(HttpErrorConstants.UNAUTHORIZED_INVALIE_SIGNATURE);
       }
     }
   }

--- a/src/domains/auth/repositories/refresh-token.repository.ts
+++ b/src/domains/auth/repositories/refresh-token.repository.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
+import { RefreshToken } from '../entities/refresh-token.entity';
+import { User } from 'src/domains/user/entities/user.entity';
+import { PlatFormEnumType } from '../consts/platform.const';
+
+@Injectable()
+export class RefreshTokenRepository extends Repository<RefreshToken> {
+  constructor(private dataSource: DataSource) {
+    super(RefreshToken, dataSource.createEntityManager());
+  }
+
+  /**
+   * 상태에 따른 리프레시 값 변경
+   * @param user User
+   * @param refToken refreshToken
+   * @param platForm signup Platform
+   * @returns
+   */
+  async updateOrCreateRefToken(user: User, refToken: string, platForm: PlatFormEnumType) {
+    let userToken = await this.findOne({
+      where: {
+        user,
+      },
+    });
+
+    if (userToken) {
+      userToken.refToken = refToken;
+    } else {
+      userToken = this.create({
+        refToken,
+        user,
+        platForm,
+      });
+    }
+    await this.save(userToken);
+  }
+}

--- a/src/domains/auth/repositories/refresh-token.repository.ts
+++ b/src/domains/auth/repositories/refresh-token.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { DataSource, Repository } from 'typeorm';
+import { DataSource, QueryRunner, Repository } from 'typeorm';
 import { RefreshToken } from '../entities/refresh-token.entity';
 import { User } from 'src/domains/user/entities/user.entity';
 import { PlatFormEnumType } from '../consts/platform.const';
@@ -15,10 +15,11 @@ export class RefreshTokenRepository extends Repository<RefreshToken> {
    * @param user User
    * @param refToken refreshToken
    * @param platForm signup Platform
+   * @param qr QueryRunner
    * @returns
    */
-  async updateOrCreateRefToken(user: User, refToken: string, platForm: PlatFormEnumType) {
-    let userToken = await this.findOne({
+  async updateOrCreateRefToken(user: User, refToken: string, platForm: PlatFormEnumType, qr: QueryRunner) {
+    let userToken = await qr.manager.findOne(RefreshToken, {
       where: {
         user,
       },
@@ -33,6 +34,6 @@ export class RefreshTokenRepository extends Repository<RefreshToken> {
         platForm,
       });
     }
-    await this.save(userToken);
+    await qr.manager.save(RefreshToken, userToken);
   }
 }

--- a/src/domains/auth/swagger/rest-swagger.decorator.ts
+++ b/src/domains/auth/swagger/rest-swagger.decorator.ts
@@ -56,11 +56,7 @@ export const RotateAccessTokenDocs = () => {
       },
       {
         status: StatusCodes.UNAUTHORIZED,
-        errorFormatList: [
-          HttpErrorConstants.INVALID_TOKEN,
-          HttpErrorConstants.NOT_FOUND_TOKEN,
-          HttpErrorConstants.EXPIRED_TOKEN,
-        ],
+        errorFormatList: HttpErrorConstants.COMMON_UNAUTHORIZED_TOKEN_ERROR,
       },
     ]),
   );
@@ -87,11 +83,7 @@ export const LogOutDocs = () => {
     ApiErrorResponseTemplate([
       {
         status: StatusCodes.UNAUTHORIZED,
-        errorFormatList: [
-          HttpErrorConstants.INVALID_TOKEN,
-          HttpErrorConstants.NOT_FOUND_TOKEN,
-          HttpErrorConstants.EXPIRED_TOKEN,
-        ],
+        errorFormatList: HttpErrorConstants.COMMON_UNAUTHORIZED_TOKEN_ERROR,
       },
     ]),
   );

--- a/src/domains/auth/swagger/rest-swagger.decorator.ts
+++ b/src/domains/auth/swagger/rest-swagger.decorator.ts
@@ -1,5 +1,5 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiBody, ApiHeader, ApiOperation } from '@nestjs/swagger';
+import { ApiBody, ApiHeader, ApiNoContentResponse, ApiOperation } from '@nestjs/swagger';
 import { StatusCodes } from 'http-status-codes';
 import { HttpErrorConstants } from 'src/core/http/http-error-objects';
 import { ApiCreatedResponseTemplate } from 'src/core/swagger/api-created-response';
@@ -54,6 +54,37 @@ export const RotateAccessTokenDocs = () => {
         status: StatusCodes.BAD_REQUEST,
         errorFormatList: [HttpErrorConstants.VALIDATE_ERROR],
       },
+      {
+        status: StatusCodes.UNAUTHORIZED,
+        errorFormatList: [
+          HttpErrorConstants.INVALID_TOKEN,
+          HttpErrorConstants.NOT_FOUND_TOKEN,
+          HttpErrorConstants.EXPIRED_TOKEN,
+        ],
+      },
+    ]),
+  );
+};
+
+/**로그아웃 */
+export const LogOutDocs = () => {
+  return applyDecorators(
+    ApiOperation({
+      summary: '로그아웃',
+      description: `
+      - 헤더에 authorization key로 Bearer AccessToken을 요청
+      - 응답 성공시 204 noContent를 반환한다 
+      `,
+    }),
+    ApiHeader({
+      name: 'authorization',
+      description: 'access token in Bearer format',
+      required: true,
+    }),
+    ApiNoContentResponse({
+      description: '로그아웃 성공 - 반환되는 데이터는 별도로 없다',
+    }),
+    ApiErrorResponseTemplate([
       {
         status: StatusCodes.UNAUTHORIZED,
         errorFormatList: [

--- a/src/domains/auth/swagger/rest-swagger.decorator.ts
+++ b/src/domains/auth/swagger/rest-swagger.decorator.ts
@@ -1,11 +1,11 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiBody, ApiOperation } from '@nestjs/swagger';
+import { ApiBody, ApiHeader, ApiOperation } from '@nestjs/swagger';
 import { StatusCodes } from 'http-status-codes';
 import { HttpErrorConstants } from 'src/core/http/http-error-objects';
 import { ApiCreatedResponseTemplate } from 'src/core/swagger/api-created-response';
 import { ApiErrorResponseTemplate } from 'src/core/swagger/api-error-response';
 import { SocialUserDto } from 'src/domains/user/dto/social-user.dto';
-import { LoginResponseDto } from '../dtos/login-response.dto';
+import { LoginResponseDto, RotateAccessTokenDto } from '../dtos/login-response.dto';
 
 /**소셜 가입 & 로그인*/
 export const SocialLoginDocs = () => {
@@ -26,6 +26,41 @@ export const SocialLoginDocs = () => {
       {
         status: StatusCodes.BAD_REQUEST,
         errorFormatList: [HttpErrorConstants.VALIDATE_ERROR],
+      },
+    ]),
+  );
+};
+
+/**엑세스 토큰 재발급 */
+export const RotateAccessTokenDocs = () => {
+  return applyDecorators(
+    ApiOperation({
+      summary: '엑세스 토큰 재발급',
+      description: `
+      - 리프레시 토큰으로 엑세스 토큰을 재발급한다.
+      - 검증 절차(1. Bearer 여부,  2. Refresh 형태,  3. Token Signature,  4. RefToken 테이블에 정상적으로 등록된 토큰인지 여부) `,
+    }),
+    ApiHeader({
+      name: 'authorization',
+      description: 'refresh token in Bearer format',
+      required: true,
+    }),
+    ApiCreatedResponseTemplate({
+      description: '엑세스 토큰 재발급 성공',
+      type: RotateAccessTokenDto,
+    }),
+    ApiErrorResponseTemplate([
+      {
+        status: StatusCodes.BAD_REQUEST,
+        errorFormatList: [HttpErrorConstants.VALIDATE_ERROR],
+      },
+      {
+        status: StatusCodes.UNAUTHORIZED,
+        errorFormatList: [
+          HttpErrorConstants.INVALID_TOKEN,
+          HttpErrorConstants.NOT_FOUND_TOKEN,
+          HttpErrorConstants.EXPIRED_TOKEN,
+        ],
       },
     ]),
   );

--- a/src/domains/auth/utils/client.util.ts
+++ b/src/domains/auth/utils/client.util.ts
@@ -1,6 +1,6 @@
-import { PlatFormType } from '../consts/platform.const';
+import { PlatFormEnumType, PlatFormType } from '../consts/platform.const';
 
-export function detectPlatform(userAgent: string): string {
+export async function detectPlatform(userAgent: string): Promise<PlatFormEnumType> {
   let currentOS;
 
   const web = /mozilla/i.test(userAgent);

--- a/src/domains/user/entities/user.entity.ts
+++ b/src/domains/user/entities/user.entity.ts
@@ -1,7 +1,8 @@
+import { Exclude } from 'class-transformer';
 import { BaseModel } from 'src/common/entities/base.entity';
 import { SocialAuthEnum } from 'src/domains/auth/consts/social-auth.enum';
 import { RefreshToken } from 'src/domains/auth/entities/refresh-token.entity';
-import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, DeleteDateColumn, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
 
 @Entity()
 export class User extends BaseModel {
@@ -31,6 +32,10 @@ export class User extends BaseModel {
     comment: '소셜 가입 방식 유형',
   })
   authType: string;
+
+  @DeleteDateColumn({ default: null })
+  @Exclude()
+  deletedAt: Date | null;
 
   @OneToMany(() => RefreshToken, (refToken) => refToken.user)
   refToken: RefreshToken[];

--- a/src/domains/user/entities/user.entity.ts
+++ b/src/domains/user/entities/user.entity.ts
@@ -33,6 +33,12 @@ export class User extends BaseModel {
   })
   authType: string;
 
+  @Column({
+    type: 'boolean',
+    default: true,
+  })
+  isActive: boolean;
+
   @DeleteDateColumn({ default: null })
   @Exclude()
   deletedAt: Date | null;

--- a/src/domains/user/entities/user.entity.ts
+++ b/src/domains/user/entities/user.entity.ts
@@ -1,7 +1,7 @@
-// import { Exclude } from 'class-transformer';
 import { BaseModel } from 'src/common/entities/base.entity';
 import { SocialAuthEnum } from 'src/domains/auth/consts/social-auth.enum';
-import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { RefreshToken } from 'src/domains/auth/entities/refresh-token.entity';
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
 
 @Entity()
 export class User extends BaseModel {
@@ -32,16 +32,8 @@ export class User extends BaseModel {
   })
   authType: string;
 
-  // @Column({
-  //   type: 'varchar',
-  //   length: 255,
-  //   nullable: true,
-  //   default: null,
-  // })
-  // @Exclude({
-  //   toPlainOnly: true,
-  // })
-  // password: string;
+  @OneToMany(() => RefreshToken, (refToken) => refToken.user)
+  refToken: RefreshToken[];
 
   static signup({ email, userName, authType }: { email: string; userName: string; authType: SocialAuthEnum }) {
     const user = new User();

--- a/src/domains/user/repositories/user.repository.ts
+++ b/src/domains/user/repositories/user.repository.ts
@@ -51,6 +51,7 @@ export class UserRepository extends Repository<User> {
       select: {
         id: true,
         email: true,
+        userName: true,
         authType: true,
       },
       where: {

--- a/src/domains/user/repositories/user.repository.ts
+++ b/src/domains/user/repositories/user.repository.ts
@@ -63,7 +63,8 @@ export class UserRepository extends Repository<User> {
       return user;
     } else {
       const newUser = User.signup(dto);
-      return await this.save(newUser);
+      return newUser;
+      // return await this.save(newUser);
     }
   }
 }

--- a/src/domains/user/repositories/user.repository.ts
+++ b/src/domains/user/repositories/user.repository.ts
@@ -3,6 +3,7 @@ import { DataSource, Repository } from 'typeorm';
 import { User } from '../entities/user.entity';
 import { SocialAuthEnum } from 'src/domains/auth/consts/social-auth.enum';
 import { SocialUserDto } from '../dto/social-user.dto';
+import { TokenPayLoad } from 'src/domains/auth/interfaces/token-payload.interface';
 
 @Injectable()
 export class UserRepository extends Repository<User> {
@@ -65,7 +66,20 @@ export class UserRepository extends Repository<User> {
     } else {
       const newUser = User.signup(dto);
       return newUser;
-      // return await this.save(newUser);
     }
+  }
+
+  /**
+   * get refTokens byUser
+   * @param payLoad TokenPayload
+   * @returns Auth
+   */
+  async findAllrefToken(payLoad: TokenPayLoad): Promise<User> {
+    return await this.findOne({
+      where: {
+        id: payLoad.sub,
+      },
+      relations: ['refToken'],
+    });
   }
 }

--- a/src/domains/user/repositories/user.repository.ts
+++ b/src/domains/user/repositories/user.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { DataSource, Repository } from 'typeorm';
+import { DataSource, QueryRunner, Repository } from 'typeorm';
 import { User } from '../entities/user.entity';
 import { SocialAuthEnum } from 'src/domains/auth/consts/social-auth.enum';
 import { SocialUserDto } from '../dto/social-user.dto';
@@ -47,8 +47,8 @@ export class UserRepository extends Repository<User> {
    * @param dto SocialUserDto
    * @returns user
    */
-  async findOrCreate(dto: SocialUserDto): Promise<User> {
-    const user = await this.findOne({
+  async findOrCreate(dto: SocialUserDto, qr: QueryRunner): Promise<User> {
+    const user = await qr.manager.findOne(User, {
       select: {
         id: true,
         email: true,
@@ -65,6 +65,7 @@ export class UserRepository extends Repository<User> {
       return user;
     } else {
       const newUser = User.signup(dto);
+      await qr.manager.save(User, newUser);
       return newUser;
     }
   }

--- a/src/domains/user/swagger/rest-swagger.decorator.ts
+++ b/src/domains/user/swagger/rest-swagger.decorator.ts
@@ -1,0 +1,32 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiHeader, ApiNoContentResponse, ApiOperation } from '@nestjs/swagger';
+import { StatusCodes } from 'http-status-codes';
+import { HttpErrorConstants } from 'src/core/http/http-error-objects';
+import { ApiErrorResponseTemplate } from 'src/core/swagger/api-error-response';
+
+/**회원탈퇴*/
+export const WithdrawUserDocs = () => {
+  return applyDecorators(
+    ApiOperation({
+      summary: '회원탈퇴',
+      description: `
+        - softDelete로 회원을 탈퇴시킨다.
+        - 탈퇴된 회원의 정보는 모두 제거하지 않고, 특정 기간 보유시킨다.
+        `,
+    }),
+    ApiHeader({
+      name: 'authorization',
+      description: 'access token in Bearer format',
+      required: true,
+    }),
+    ApiNoContentResponse({
+      description: '회원탈퇴 성공',
+    }),
+    ApiErrorResponseTemplate([
+      {
+        status: StatusCodes.UNAUTHORIZED,
+        errorFormatList: HttpErrorConstants.COMMON_UNAUTHORIZED_TOKEN_ERROR,
+      },
+    ]),
+  );
+};

--- a/src/domains/user/user.controller.ts
+++ b/src/domains/user/user.controller.ts
@@ -1,11 +1,11 @@
-import { Controller, Post, Body, Res, Get, Param } from '@nestjs/common';
+import { Controller, Res, Delete, Req } from '@nestjs/common';
 import { UserService } from './user.service';
-import { CreateUserDto } from './dto/create-user.dto';
 import { ApiTags } from '@nestjs/swagger';
 import { ApiCommonErrorResponseTemplate } from 'src/core/swagger/api-error-common-response';
 
-import { Response } from 'express';
+import { Response, Request } from 'express';
 import HttpResponse from 'src/core/http/http-response';
+import { WithdrawUserDocs } from './swagger/rest-swagger.decorator';
 
 @ApiTags('User - 회원관리')
 @ApiCommonErrorResponseTemplate()
@@ -13,17 +13,24 @@ import HttpResponse from 'src/core/http/http-response';
 export class UserController {
   constructor(private readonly userService: UserService) {}
 
-  /**회원가입*/
-  @Post()
-  async register(@Body() dto: CreateUserDto, @Res() res: Response) {
-    const user = await this.userService.register(dto);
-    return HttpResponse.created(res, { body: user.id });
+  @WithdrawUserDocs()
+  @Delete()
+  async remove(@Res() res: Response, @Req() req: Request) {
+    const payLoad = req.user;
+    await this.userService.withdrawUser(payLoad);
+    return HttpResponse.noContent(res);
   }
+  // /**회원가입*/
+  // @Post()
+  // async register(@Body() dto: CreateUserDto, @Res() res: Response) {
+  //   const user = await this.userService.register(dto);
+  //   return HttpResponse.created(res, { body: user.id });
+  // }
 
-  /**이메일 중복체크*/
-  @Get('/check-email/:email')
-  async checkExistEmail(@Res() res: Response, @Param('email') email: string) {
-    const isExistEmail = await this.userService.checkExistEmail(email);
-    return HttpResponse.ok(res, isExistEmail);
-  }
+  // /**이메일 중복체크*/
+  // @Get('/check-email/:email')
+  // async checkExistEmail(@Res() res: Response, @Param('email') email: string) {
+  //   const isExistEmail = await this.userService.checkExistEmail(email);
+  //   return HttpResponse.ok(res, isExistEmail);
+  // }
 }

--- a/src/domains/user/user.service.ts
+++ b/src/domains/user/user.service.ts
@@ -1,53 +1,85 @@
-import { ConflictException, Injectable } from '@nestjs/common';
-import { CreateUserDto } from './dto/create-user.dto';
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
+
 import { UserRepository } from './repositories/user.repository';
 import { User } from './entities/user.entity';
 import { ConfigService } from '@nestjs/config';
 import { HttpErrorConstants } from 'src/core/http/http-error-objects';
-// import { SocialAuthEnum } from '../auth/consts/social-auth.enum';
-
-// import { hashedPassword } from 'src/core/utils/password.utils';
-// import { ENV_CONFIG } from 'src/common/const/env-keys.const';
-// import { hashedPhone } from 'src/core/utils/phone-number.utils';
-
+import { TokenPayLoad } from '../auth/interfaces/token-payload.interface';
+import { RefreshToken } from '../auth/entities/refresh-token.entity';
+import { DataSource } from 'typeorm';
 @Injectable()
 export class UserService {
   constructor(
     private readonly userRepository: UserRepository,
     private readonly confgiService: ConfigService,
+    private readonly dataSource: DataSource,
   ) {}
 
   /**
-   * 회원가입
-   * @param createUserDto
-   * @returns user
+   * 회원탈퇴
+   * @param payLoad
+   * @returns
    */
-  async register(dto: CreateUserDto): Promise<User> {
-    const user = User.signup(dto);
-    return await this.userRepository.save(user);
-
-    // user.password = hashedPassword(
-    //   user.password,
-    //   parseInt(this.confgiService.get<string>(ENV_CONFIG.AUTH.HASH_ROUNDS)),
-    // );
-
-    // user.phoneNumber = hashedPhone(
-    //   user.phoneNumber,
-    //   parseInt(this.confgiService.get<string>(ENV_CONFIG.AUTH.HASH_ROUNDS)),
-    // );
-  }
-
-  /**
-   * 중복 이메일 체크
-   * @param email 이메일
-   * @returns boolean
-   */
-  async checkExistEmail(email: string): Promise<boolean> {
-    const isExistEmail = await this.userRepository.existByEmail(email);
-
-    if (isExistEmail) {
-      throw new ConflictException(HttpErrorConstants.EXIST_EMAIL);
+  async withdrawUser(payLoad: TokenPayLoad): Promise<void> {
+    const qr = this.dataSource.createQueryRunner();
+    await qr.connect();
+    await qr.startTransaction();
+    try {
+      await qr.manager.softDelete(User, {
+        id: payLoad.sub,
+      });
+      await qr.manager.update(
+        User,
+        {
+          id: payLoad.sub,
+        },
+        {
+          isActive: false,
+        },
+      );
+      await qr.manager.delete(RefreshToken, {
+        user: { id: payLoad.sub },
+      });
+      await qr.commitTransaction();
+    } catch (err) {
+      await qr.rollbackTransaction();
+      console.log('error->', err);
+      throw new InternalServerErrorException(HttpErrorConstants.INTERNAL_SERVER_ERROR);
+    } finally {
+      await qr.release();
     }
-    return isExistEmail;
   }
+  // /**
+  //  * 회원가입
+  //  * @param createUserDto
+  //  * @returns user
+  //  */
+  // async register(dto: CreateUserDto): Promise<User> {
+  //   const user = User.signup(dto);
+  //   return await this.userRepository.save(user);
+
+  //   // user.password = hashedPassword(
+  //   //   user.password,
+  //   //   parseInt(this.confgiService.get<string>(ENV_CONFIG.AUTH.HASH_ROUNDS)),
+  //   // );
+
+  //   // user.phoneNumber = hashedPhone(
+  //   //   user.phoneNumber,
+  //   //   parseInt(this.confgiService.get<string>(ENV_CONFIG.AUTH.HASH_ROUNDS)),
+  //   // );
+  // }
+
+  // /**
+  //  * 중복 이메일 체크
+  //  * @param email 이메일
+  //  * @returns boolean
+  //  */
+  // async checkExistEmail(email: string): Promise<boolean> {
+  //   const isExistEmail = await this.userRepository.existByEmail(email);
+
+  //   if (isExistEmail) {
+  //     throw new ConflictException(HttpErrorConstants.EXIST_EMAIL);
+  //   }
+  //   return isExistEmail;
+  // }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #13  소셜 가입 및 로그인 기능을 제외한 authenticate 통합 모듈을 개발한다

## 📝작업 내용

- RefreshToken을 테이블에서 관리하도록 Entity를 추가완료.
- Bearer 방식의 토큰 인증 모듈 및 기본적인 로그아웃, 회원탈퇴 로직 개발 완료. 
- 회원탈퇴는 softDelete 방식을 개발.
- 로그인&가입, 엑세스토큰 재발급 로직을 제외한 모든 엔드포인트에 공용으로 필요한 Bearer Access Token Middleware를 글로벌 미들웨어로 등록 -> Auth Module의 의존성 제거.
