### PR TITLE
[#16] 유저 정보조회를 위한 엔드포인트를 추가하고 엔드포인트 반환시 직렬화가 반영되지 않는 이슈를 해결한다. 

### DIFF
--- a/src/app.middleware.ts
+++ b/src/app.middleware.ts
@@ -1,5 +1,5 @@
 import { INestApplication } from '@nestjs/common';
-import * as csurf from 'csurf';
+// import * as csurf from 'csurf';
 import * as helmet from 'helmet';
 import * as hpp from 'hpp';
 import * as compression from 'compression';
@@ -13,7 +13,7 @@ export function middleware(app: INestApplication): INestApplication {
   app.use(compression());
 
   if (isProduction) {
-    app.use(csurf());
+    // app.use(csurf());
 
     app.use(hpp());
 

--- a/src/common/entities/base.entity.ts
+++ b/src/common/entities/base.entity.ts
@@ -2,14 +2,15 @@ import { CreateDateColumn, UpdateDateColumn, VersionColumn } from 'typeorm';
 import { Exclude } from 'class-transformer';
 
 export abstract class BaseModel {
+  // @Exclude()
   @CreateDateColumn()
-  @Exclude()
   createdAt: Date;
 
-  @UpdateDateColumn()
   @Exclude()
+  @UpdateDateColumn()
   updatedAt: Date;
 
+  @Exclude()
   @VersionColumn()
   version: number;
 }

--- a/src/core/http/http-response.ts
+++ b/src/core/http/http-response.ts
@@ -1,46 +1,72 @@
-import responseJson from './response-json';
-import status from 'http-status-codes';
-import { Response } from 'express';
+import { HttpStatus } from '@nestjs/common';
+
 /**
  * HTTP 응답 클래스
  * - 컨트롤러 함수에서 리턴을 하면 응답 데이터 형식에 맞게 응답한다.
- *
+ * - Serialization 호환 되도록 설정
  * @see TransformationInterceptor
  */
 
-export default class HttpResponse {
-  static ok<T>(res: Response, body?: T): Response<unknown> {
-    return res.status(status.OK).json(responseJson(status.OK, body));
+export class HttpResponse {
+  static ok<T>(body?: T): { statusCode: number; message: string; result?: T } {
+    return {
+      statusCode: HttpStatus.OK,
+      message: 'OK',
+      result: body,
+    };
   }
 
-  static created<T>(res: Response, params?: { uri?: string; body?: T }): Response<unknown> {
-    if (params && params.uri) {
-      res.setHeader('Location', params.uri);
-    }
-    return res.status(status.CREATED).json(responseJson(status.CREATED, params ? params.body : undefined));
+  static created<T>(body?: T): { statusCode: number; message: string; result?: T } {
+    return {
+      statusCode: HttpStatus.CREATED,
+      message: 'Created',
+      result: body,
+    };
+  }
+  static noContent(): { statusCode: number; message: string } {
+    return {
+      statusCode: HttpStatus.NO_CONTENT,
+      message: 'No Content',
+    };
   }
 
-  static noContent(res: Response): Response<unknown> {
-    return res.status(status.NO_CONTENT).json();
+  static badRequest<T>(error?: T | Error): { statusCode: number; message: string; error?: T | Error } {
+    return {
+      statusCode: HttpStatus.BAD_REQUEST,
+      message: 'Bad Request',
+      error: error,
+    };
   }
 
-  static badRequest<T>(res: Response, object?: T | Error): Response<unknown> {
-    return res.status(status.BAD_REQUEST).json(responseJson(status.BAD_REQUEST, object));
+  static unauthorized<T>(error?: T | Error): { statusCode: number; message: string; error?: T | Error } {
+    return {
+      statusCode: HttpStatus.UNAUTHORIZED,
+      message: 'Unauthorized',
+      error: error,
+    };
   }
 
-  static unauthorized<T>(res: Response, object?: T | Error): Response<unknown> {
-    return res.status(status.UNAUTHORIZED).json(responseJson(status.UNAUTHORIZED, object));
+  static notFound<T>(error?: T | Error): { statusCode: number; message: string; error?: T | Error } {
+    return {
+      statusCode: HttpStatus.NOT_FOUND,
+      message: 'Not Found',
+      error: error,
+    };
   }
 
-  static notFound<T>(res: Response, object?: T | Error): Response<unknown> {
-    return res.status(status.NOT_FOUND).json(responseJson(status.NOT_FOUND, object));
+  static unprocessableEntity<T>(error?: T | Error): { statusCode: number; message: string; error?: T | Error } {
+    return {
+      statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+      message: 'Unprocessable Entity',
+      error: error,
+    };
   }
 
-  static unprocessableEntity<T>(res: Response, object?: T | Error): Response<unknown> {
-    return res.status(status.UNPROCESSABLE_ENTITY).json(responseJson(status.UNPROCESSABLE_ENTITY, object));
-  }
-
-  static internalServerError<T>(res: Response, object?: T | Error): Response<unknown> {
-    return res.status(status.INTERNAL_SERVER_ERROR).json(responseJson(status.INTERNAL_SERVER_ERROR, object));
+  static internalServerError<T>(error?: T | Error): { statusCode: number; message: string; error?: T | Error } {
+    return {
+      statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+      message: 'Internal Server Error',
+      error: error,
+    };
   }
 }

--- a/src/domains/auth/auth.controller.ts
+++ b/src/domains/auth/auth.controller.ts
@@ -1,14 +1,15 @@
-import { Body, Controller, Post, Req, Res, UseGuards } from '@nestjs/common';
+import { Body, Controller, HttpCode, Post, Req, UseGuards } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { ApiTags } from '@nestjs/swagger';
 import { ApiCommonErrorResponseTemplate } from 'src/core/swagger/api-error-common-response';
 
-import { Response, Request } from 'express';
-import HttpResponse from 'src/core/http/http-response';
+import { Request } from 'express';
+
 import { SocialUserDto } from '../user/dto/social-user.dto';
 import { LogOutDocs, RotateAccessTokenDocs, SocialLoginDocs } from './swagger/rest-swagger.decorator';
 import { RefreshTokenGuard } from './guards/refresh-token.guard';
 import { Authorization } from './deocorators/authorization.decorator';
+import { HttpResponse } from 'src/core/http/http-response';
 
 @ApiTags('Auth - 인증')
 @ApiCommonErrorResponseTemplate()
@@ -19,27 +20,28 @@ export class AuthController {
   // 소셜 가입 & 로그인
   @SocialLoginDocs()
   @Post('social-login')
-  async socialLogin(@Req() req: Request, @Res() res: Response, @Body() dto: SocialUserDto) {
+  async socialLogin(@Req() req: Request, @Body() dto: SocialUserDto) {
     const token = await this.authService.socialLogin(req.get('user-agent').toLowerCase(), dto);
-    return HttpResponse.created(res, { body: token });
+    return HttpResponse.created(token);
   }
 
   // 토큰 재발급
   @RotateAccessTokenDocs()
   @UseGuards(RefreshTokenGuard)
   @Post('token/access')
-  async rotateAccessToken(@Res() res: Response, @Req() req: Request, @Authorization() token: string) {
+  async rotateAccessToken(@Req() req: Request, @Authorization() token: string) {
     const payload = req.user;
     const accessToken = await this.authService.rotateAccessToken(payload, token);
-    return HttpResponse.created(res, { body: accessToken });
+    return HttpResponse.created({ accessToken });
   }
 
   // 로그아웃
   @LogOutDocs()
   @Post('logout')
-  async logOut(@Res() res: Response, @Req() req: Request) {
+  @HttpCode(204)
+  async logOut(@Req() req: Request) {
     const payload = req.user;
     await this.authService.removeRefToken(payload);
-    return HttpResponse.noContent(res);
+    return HttpResponse.noContent();
   }
 }

--- a/src/domains/user/dto/find-user.response.dto.ts
+++ b/src/domains/user/dto/find-user.response.dto.ts
@@ -1,0 +1,29 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Exclude } from 'class-transformer';
+
+export class FindOneUserResponseDto {
+  @ApiProperty({
+    description: '유저 id number',
+    example: 1,
+  })
+  id: number;
+
+  @ApiProperty({
+    description: '이메일',
+    example: 'cs12@cs.com',
+  })
+  email: string;
+
+  @ApiProperty({
+    description: '이름',
+    example: 'dino',
+  })
+  userName: string;
+
+  @Exclude()
+  @ApiProperty({
+    description: '인증타입',
+    example: 'kakao | naver | apple | google',
+  })
+  authType: string;
+}

--- a/src/domains/user/entities/user.entity.ts
+++ b/src/domains/user/entities/user.entity.ts
@@ -26,6 +26,7 @@ export class User extends BaseModel {
   })
   userName: string;
 
+  @Exclude()
   @Column({
     type: 'enum',
     enum: Object.values(SocialAuthEnum),
@@ -33,14 +34,15 @@ export class User extends BaseModel {
   })
   authType: string;
 
+  @Exclude()
   @Column({
     type: 'boolean',
     default: true,
   })
   isActive: boolean;
 
-  @DeleteDateColumn({ default: null })
   @Exclude()
+  @DeleteDateColumn({ default: null })
   deletedAt: Date | null;
 
   @OneToMany(() => RefreshToken, (refToken) => refToken.user)

--- a/src/domains/user/repositories/user.repository.ts
+++ b/src/domains/user/repositories/user.repository.ts
@@ -71,7 +71,7 @@ export class UserRepository extends Repository<User> {
   }
 
   /**
-   * get refTokens byUser
+   * get ref-token by user
    * @param payLoad TokenPayload
    * @returns Auth
    */
@@ -81,6 +81,19 @@ export class UserRepository extends Repository<User> {
         id: payLoad.sub,
       },
       relations: ['refToken'],
+    });
+  }
+
+  /**
+   * payLoad sub based user find
+   * @param payLoad TokenPayload
+   * @returns User
+   */
+  async findById(papyLoad: TokenPayLoad): Promise<User> {
+    return await this.findOne({
+      where: {
+        id: papyLoad.sub,
+      },
     });
   }
 }

--- a/src/domains/user/swagger/rest-swagger.decorator.ts
+++ b/src/domains/user/swagger/rest-swagger.decorator.ts
@@ -3,6 +3,8 @@ import { ApiHeader, ApiNoContentResponse, ApiOperation } from '@nestjs/swagger';
 import { StatusCodes } from 'http-status-codes';
 import { HttpErrorConstants } from 'src/core/http/http-error-objects';
 import { ApiErrorResponseTemplate } from 'src/core/swagger/api-error-response';
+import { FindOneUserResponseDto } from '../dto/find-user.response.dto';
+import { ApiOkResponseTemplate } from 'src/core/swagger/api-ok-response';
 
 /**회원탈퇴*/
 export const WithdrawUserDocs = () => {
@@ -26,6 +28,37 @@ export const WithdrawUserDocs = () => {
       {
         status: StatusCodes.UNAUTHORIZED,
         errorFormatList: HttpErrorConstants.COMMON_UNAUTHORIZED_TOKEN_ERROR,
+      },
+    ]),
+  );
+};
+
+/**단일조회*/
+export const FindByIdDocs = () => {
+  return applyDecorators(
+    ApiOperation({
+      summary: '단일 유저 조회 ',
+      description: `
+        - accessToken 값으로 유저 정보를 단일로 조회한다.
+        `,
+    }),
+    ApiHeader({
+      name: 'authorization',
+      description: 'access token in Bearer format',
+      required: true,
+    }),
+    ApiOkResponseTemplate({
+      description: '유저 단일 조회 성공',
+      type: FindOneUserResponseDto,
+    }),
+    ApiErrorResponseTemplate([
+      {
+        status: StatusCodes.UNAUTHORIZED,
+        errorFormatList: HttpErrorConstants.COMMON_UNAUTHORIZED_TOKEN_ERROR,
+      },
+      {
+        status: StatusCodes.NOT_FOUND,
+        errorFormatList: [HttpErrorConstants.NOT_FOUND_USER],
       },
     ]),
   );

--- a/src/domains/user/user.controller.ts
+++ b/src/domains/user/user.controller.ts
@@ -1,13 +1,14 @@
-import { Controller, Res, Delete, Req } from '@nestjs/common';
+import { Controller, Delete, Req, Get, ClassSerializerInterceptor, UseInterceptors } from '@nestjs/common';
 import { UserService } from './user.service';
 import { ApiTags } from '@nestjs/swagger';
 import { ApiCommonErrorResponseTemplate } from 'src/core/swagger/api-error-common-response';
 
-import { Response, Request } from 'express';
-import HttpResponse from 'src/core/http/http-response';
-import { WithdrawUserDocs } from './swagger/rest-swagger.decorator';
+import { Request } from 'express';
+import { FindByIdDocs, WithdrawUserDocs } from './swagger/rest-swagger.decorator';
+import { HttpResponse } from 'src/core/http/http-response';
 
 @ApiTags('User - 회원관리')
+@UseInterceptors(ClassSerializerInterceptor) // 직렬화 인터셉터
 @ApiCommonErrorResponseTemplate()
 @Controller('users')
 export class UserController {
@@ -15,22 +16,17 @@ export class UserController {
 
   @WithdrawUserDocs()
   @Delete()
-  async remove(@Res() res: Response, @Req() req: Request) {
+  async remove(@Req() req: Request) {
     const payLoad = req.user;
     await this.userService.withdrawUser(payLoad);
-    return HttpResponse.noContent(res);
+    return HttpResponse.noContent();
   }
-  // /**회원가입*/
-  // @Post()
-  // async register(@Body() dto: CreateUserDto, @Res() res: Response) {
-  //   const user = await this.userService.register(dto);
-  //   return HttpResponse.created(res, { body: user.id });
-  // }
 
-  // /**이메일 중복체크*/
-  // @Get('/check-email/:email')
-  // async checkExistEmail(@Res() res: Response, @Param('email') email: string) {
-  //   const isExistEmail = await this.userService.checkExistEmail(email);
-  //   return HttpResponse.ok(res, isExistEmail);
-  // }
+  @FindByIdDocs()
+  @Get()
+  async findById(@Req() req: Request) {
+    const payLoad = req.user;
+    const user = await this.userService.findById(payLoad);
+    return HttpResponse.ok(user);
+  }
 }

--- a/src/domains/user/user.service.ts
+++ b/src/domains/user/user.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
 
 import { UserRepository } from './repositories/user.repository';
 import { User } from './entities/user.entity';
@@ -49,37 +49,17 @@ export class UserService {
       await qr.release();
     }
   }
-  // /**
-  //  * 회원가입
-  //  * @param createUserDto
-  //  * @returns user
-  //  */
-  // async register(dto: CreateUserDto): Promise<User> {
-  //   const user = User.signup(dto);
-  //   return await this.userRepository.save(user);
 
-  //   // user.password = hashedPassword(
-  //   //   user.password,
-  //   //   parseInt(this.confgiService.get<string>(ENV_CONFIG.AUTH.HASH_ROUNDS)),
-  //   // );
-
-  //   // user.phoneNumber = hashedPhone(
-  //   //   user.phoneNumber,
-  //   //   parseInt(this.confgiService.get<string>(ENV_CONFIG.AUTH.HASH_ROUNDS)),
-  //   // );
-  // }
-
-  // /**
-  //  * 중복 이메일 체크
-  //  * @param email 이메일
-  //  * @returns boolean
-  //  */
-  // async checkExistEmail(email: string): Promise<boolean> {
-  //   const isExistEmail = await this.userRepository.existByEmail(email);
-
-  //   if (isExistEmail) {
-  //     throw new ConflictException(HttpErrorConstants.EXIST_EMAIL);
-  //   }
-  //   return isExistEmail;
-  // }
+  /**
+   * 유저 단일 조회
+   * @param payLoad
+   * @returns
+   */
+  async findById(payLoad: TokenPayLoad): Promise<User> {
+    const user = await this.userRepository.findById(payLoad);
+    if (!user) {
+      throw new NotFoundException(HttpErrorConstants.NOT_FOUND_USER);
+    }
+    return user;
+  }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #16 유저 정보조회를 위한 엔드포인트를 추가하고 엔드포인트 반환시 직렬화가 반영되지 않는 이슈를 해결한다. 

## 📝작업 내용

-  유저 단일 정보 조회 엔드포인트 추가
- Express Response 객체로 매핑후 응답하는 방식 제거 및 마이그레이션
- csurf 모듈 제거 -> 임시 
- 엔티티에서 직렬화 필요한 부분 transformer로 Exlude

