### PR TITLE
fix: 유저 프로필 수정시 프로필 id 값을 프로필을 업데이트 하도록 수정 #31

### DIFF
--- a/src/domain/user/interface/profile.repository.interface.ts
+++ b/src/domain/user/interface/profile.repository.interface.ts
@@ -3,6 +3,7 @@ import { CreateUserProfileDto } from '../dto/request/create-user-profile.dto';
 import { UpdateUserProfileDto } from '../dto/request/update-user-profile.dto';
 
 export interface IProfileRepository {
+  findById(id: number): Promise<Profile>;
   findByUserId(userId: number): Promise<Profile>;
   create(dto: CreateUserProfileDto, userId: number): Promise<Profile>;
   update(id: number, dto: UpdateUserProfileDto): Promise<Profile>;

--- a/src/domain/user/repository/profile.repository.ts
+++ b/src/domain/user/repository/profile.repository.ts
@@ -10,6 +10,21 @@ export class ProfileRepository implements IProfileRepository {
   constructor(private readonly prisma: PrismaService) {}
 
   /**
+   * @todo 추후 prisma 기본 메서드는 BaseRepository로 추상화 예정
+   *
+   * id 기반 프로필 조회
+   * @param id profileId
+   * @returns Profile
+   */
+  async findById(id: number): Promise<Profile> {
+    return this.prisma.profile.findUnique({
+      where: {
+        id,
+      },
+    });
+  }
+
+  /**
    * userId 기반 프로필 조회
    * @param userId
    * @returns Profile
@@ -22,6 +37,14 @@ export class ProfileRepository implements IProfileRepository {
     });
   }
 
+  /**
+   * @todo 추후 prisma 기본 메서드는 BaseRepository로 추상화 예정
+   *
+   * 프로필 생성
+   * @param dto
+   * @param userId
+   * @returns Profile
+   */
   async create(dto: CreateUserProfileDto, userId: number): Promise<Profile> {
     return this.prisma.profile.create({
       data: {
@@ -36,6 +59,14 @@ export class ProfileRepository implements IProfileRepository {
     });
   }
 
+  /**
+   * @todo 추후 prisma 기본 메서드는 BaseRepository로 추상화 예정
+   *
+   * 프로필 업데이트
+   * @param id profileId
+   * @param dto
+   * @returns Profile
+   */
   async update(id: number, dto: UpdateUserProfileDto): Promise<Profile> {
     return this.prisma.profile.update({
       where: { id },

--- a/src/domain/user/user.service.ts
+++ b/src/domain/user/user.service.ts
@@ -48,14 +48,14 @@ export class UserService {
    */
   async updateProfile(id: number, dto: UpdateUserProfileDto): Promise<Profile> {
     // 1) 프로필 조회
-    const profile = await this.profileRepository.findByUserId(id);
+    const profile = await this.profileRepository.findById(id);
 
     if (!profile) throw new NotFoundException(HttpUserErrorConstants.NOT_FOUND_PROFILE);
 
     // 2) 프로필 업데이트
     await this.profileRepository.update(id, dto);
 
-    return await this.profileRepository.findByUserId(id);
+    return await this.profileRepository.findById(id);
   }
 
   /**


### PR DESCRIPTION
## #️⃣연관된 이슈

> #31 

## 📝작업 내용
- users/profile/:id 엔드포인트에 내부 비즈니스 로직에서 id 값을 userId 기반 프로필을 찾는 repository 메서드로 넘기는 이슈 수정.
- 기존에 params의 id 값을 profile Id값이 아닌 userId로 인지하고 비즈니스 로직을 처리하는 부분을 해결.

