### PR TITLE
fix: 유저 프로필 수정시 프로필 id 값을 프로필을 업데이트 하도록 수정 #33

### DIFF
--- a/src/domain/user/user.service.ts
+++ b/src/domain/user/user.service.ts
@@ -68,7 +68,7 @@ export class UserService {
       await this.prisma.$transaction(async (tx) => {
         await tx.user.update({ where: { id: userId }, data: { deletedAt: new Date() } });
         await tx.token.deleteMany({ where: { userId } });
-        await tx.profile.delete({ where: { userId } });
+        await tx.profile.deleteMany({ where: { userId } });
       });
     } catch (err) {
       console.error('Transaction error:', err);


### PR DESCRIPTION
## #️⃣연관된 이슈

> #33

## 📝작업 내용
- prisma orm에서 데이터 무결성 보장을 위해 delete 메서드는 실제 존재하는 필드를 체킹하고 없으면 exception 밷음 -> deleteMany로 변경 