### PR TITLE
refactor: 최초 가입시 사용자 기본 프로필 생성 로직 추가 

### DIFF
--- a/src/auth/application/auth.service.ts
+++ b/src/auth/application/auth.service.ts
@@ -138,7 +138,6 @@ export class AuthService {
         return { accessToken, refreshToken };
       });
 
-      this.logger.log(`[로컬 로그인 & 가입]${dto.email} 유저가 회원가입 or 로그인을 완료했습니다 🎉`);
       return result;
     } catch (err) {
       console.error('error->', err);

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -13,9 +13,11 @@ import { HttpModule } from '@nestjs/axios';
 import { PassportModule } from '@nestjs/passport';
 import { JwtStrategy } from 'src/auth/infrastructure/strategy/jwt.strategy';
 import { JwtRefreshStrategy } from 'src/auth/infrastructure/strategy/jwt-refresh.strategy';
-import { TOKEN_REPOSITORY, USER_REPOSITORY } from 'src/common/config/common.const';
+import { PROFILE_REPOSITORY, TOKEN_REPOSITORY, USER_REPOSITORY } from 'src/common/config/common.const';
 import { PrismaService } from 'src/infrastructure/database/prisma/prisma.service';
 import { UserRepository } from 'src/user/infrastructure/repository/user.repository';
+import { SlackService } from 'src/infrastructure/slack/slack.service';
+import { ProfileRepository } from 'src/user/infrastructure/repository/profile.repository';
 
 @Module({
   imports: [JwtModule.register({}), HttpModule.register({}), PassportModule],
@@ -30,12 +32,17 @@ import { UserRepository } from 'src/user/infrastructure/repository/user.reposito
       provide: USER_REPOSITORY,
       useClass: UserRepository,
     },
+    {
+      provide: PROFILE_REPOSITORY,
+      useClass: ProfileRepository,
+    },
     NaverStrategy,
     GoogleStrategy,
     AppleStrategy,
     JwtStrategy,
     JwtRefreshStrategy,
     PrismaService,
+    SlackService,
   ],
   exports: [AuthService, JwtModule, PassportModule, JwtStrategy, JwtRefreshStrategy],
 })

--- a/src/user/application/helper/profile.factory.ts
+++ b/src/user/application/helper/profile.factory.ts
@@ -1,0 +1,30 @@
+import { CreateUserProfileDto } from 'src/user/presentation/dto/request/create-user-profile.dto';
+
+const generateNickName = (): string => {
+  const adjectives = ['happy', 'lazy', 'blue', 'fuzzy', 'quick'];
+  const animals = ['dino', 'cat', 'fox', 'panda', 'lion'];
+  const nickname = `${adjectives[Math.floor(Math.random() * adjectives.length)]}-${animals[Math.floor(Math.random() * animals.length)]}-${Math.floor(Math.random() * 1000)}`;
+  return nickname.substring(0, 20); // 최대 20자 제한
+};
+
+const generateRandomInt = (min: number, max: number): number => {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+};
+
+const generateHexColor = (): string => {
+  return `#${Math.floor(Math.random() * 0xffffff)
+    .toString(16)
+    .padStart(6, '0')
+    .toUpperCase()}`;
+};
+
+export const buildDefaultProfile = (input?: Partial<CreateUserProfileDto>): CreateUserProfileDto => {
+  return {
+    nickName: input?.nickName ?? generateNickName(),
+    comment: input?.comment ?? '소개를 작성해주세요',
+    headerId: input?.headerId ?? generateRandomInt(1, 5),
+    bodyId: input?.bodyId ?? generateRandomInt(1, 5),
+    headerColor: input?.headerColor ?? generateHexColor(),
+    bodyColor: input?.bodyColor ?? generateHexColor(),
+  };
+};

--- a/src/user/application/user.service.ts
+++ b/src/user/application/user.service.ts
@@ -62,14 +62,14 @@ export class UserService {
   }
 
   /**
-   * 회원탈퇴 ( soft delete )
+   * 회원탈퇴 - 현 정책상 softDelete 하지 않고 Delete 처리
    * @param userId
    * @returns
    */
   async withdrawUser(userId: number): Promise<void> {
     try {
       await this.prisma.$transaction(async (tx) => {
-        await this.userRepository.softDeleteUserInTransaction(userId, tx);
+        await this.userRepository.deleteById(userId, tx);
         await this.tokenRepository.deleteManyByUserId(userId, tx);
         await this.profileRepository.deleteManyByUserId(userId, tx);
       });

--- a/src/user/domain/repository/profile.repository.interface.ts
+++ b/src/user/domain/repository/profile.repository.interface.ts
@@ -4,7 +4,7 @@ import { UpdateUserProfileDto } from '../../presentation/dto/request/update-user
 import { IRepository } from 'src/infrastructure/database/prisma/repository.interface';
 
 export interface IProfileRepository extends IRepository<Profile> {
-  createProfile(dto: CreateUserProfileDto, userId: number): Promise<Profile>;
+  createProfile(dto: CreateUserProfileDto, userId: number, tx?: Prisma.TransactionClient): Promise<Profile>;
   updateById(id: number, dto: UpdateUserProfileDto): Promise<Profile>;
   deleteManyByUserId(userId: number, tx: Prisma.TransactionClient): Promise<Prisma.BatchPayload>;
 }

--- a/src/user/domain/repository/user.repository.interface.ts
+++ b/src/user/domain/repository/user.repository.interface.ts
@@ -6,9 +6,9 @@ import { IRepository } from 'src/infrastructure/database/prisma/repository.inter
 export interface IUserRepository extends IRepository<User> {
   existByEmail(email: string): Promise<boolean>;
   existByEmailAndAuthType(email: string): Promise<boolean>;
-  findOrCreateSocialUser(dto: SocialUserDto, tx?: Prisma.TransactionClient): Promise<User>;
+  findOrCreateSocialUser(dto: SocialUserDto, tx?: Prisma.TransactionClient): Promise<{ user: User; isNew: boolean }>;
   findAllRefToken(userId: number): Promise<Prisma.UserGetPayload<{ include: { tokens: true } }> | null>;
-  findOrCreateLocalUser(dto: CreateUserDto, tx?: Prisma.TransactionClient): Promise<User>;
+  findOrCreateLocalUser(dto: CreateUserDto, tx?: Prisma.TransactionClient): Promise<{ user: User; isNew: boolean }>;
   softDeleteUserInTransaction(userId: number, tx: Prisma.TransactionClient): Promise<User>;
   findByUnique<K extends keyof User>(key: K, value: User[K], tx?: Prisma.TransactionClient): Promise<User | null>;
 }

--- a/src/user/domain/repository/user.repository.interface.ts
+++ b/src/user/domain/repository/user.repository.interface.ts
@@ -11,4 +11,5 @@ export interface IUserRepository extends IRepository<User> {
   findOrCreateLocalUser(dto: CreateUserDto, tx?: Prisma.TransactionClient): Promise<{ user: User; isNew: boolean }>;
   softDeleteUserInTransaction(userId: number, tx: Prisma.TransactionClient): Promise<User>;
   findByUnique<K extends keyof User>(key: K, value: User[K], tx?: Prisma.TransactionClient): Promise<User | null>;
+  deleteById(id: number, tx?: Prisma.TransactionClient): Promise<User>;
 }

--- a/src/user/infrastructure/repository/profile.repository.ts
+++ b/src/user/infrastructure/repository/profile.repository.ts
@@ -18,8 +18,9 @@ export class ProfileRepository extends PrismaRepository<Profile> implements IPro
    * @param userId
    * @returns Profile
    */
-  async createProfile(dto: CreateUserProfileDto, userId: number): Promise<Profile> {
-    return this.prisma.profile.create({
+  async createProfile(dto: CreateUserProfileDto, userId: number, tx?: Prisma.TransactionClient): Promise<Profile> {
+    const client = tx ?? this.prisma;
+    return client.profile.create({
       data: {
         userId,
         nickName: dto.nickName,

--- a/src/user/infrastructure/repository/user.repository.ts
+++ b/src/user/infrastructure/repository/user.repository.ts
@@ -39,15 +39,18 @@ export class UserRepository extends PrismaRepository<User> implements IUserRepos
    * @param dto SocialUserDto
    * @returns user
    */
-  async findOrCreateSocialUser(dto: SocialUserDto, tx?: Prisma.TransactionClient): Promise<User> {
+  async findOrCreateSocialUser(
+    dto: SocialUserDto,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{ user: User; isNew: boolean }> {
     const client = tx ?? this.prisma;
     const user = await client.user.findUnique({
       where: { email: dto.email },
     });
 
-    if (user) return user;
+    if (user) return { user, isNew: false };
 
-    return client.user.create({
+    const newUser = await client.user.create({
       data: {
         email: dto.email,
         name: dto.name,
@@ -55,6 +58,8 @@ export class UserRepository extends PrismaRepository<User> implements IUserRepos
         providerId: dto.providerId,
       },
     });
+
+    return { user: newUser, isNew: true };
   }
 
   /**
@@ -90,22 +95,27 @@ export class UserRepository extends PrismaRepository<User> implements IUserRepos
    * @param dto CreateUserDto
    * @returns
    */
-  async findOrCreateLocalUser(dto: CreateUserDto, tx?: Prisma.TransactionClient): Promise<User> {
+  async findOrCreateLocalUser(
+    dto: CreateUserDto,
+    tx?: Prisma.TransactionClient,
+  ): Promise<{ user: User; isNew: boolean }> {
     const client = tx ?? this.prisma;
     const user = await client.user.findUnique({
       where: {
         email: dto.email,
       },
     });
-    if (user) return user;
+    if (user) return { user, isNew: false };
 
-    return client.user.create({
+    const newUser = await client.user.create({
       data: {
         email: dto.email,
         name: dto.name,
         password: hashPassword(dto.password),
       },
     });
+
+    return { user: newUser, isNew: true };
   }
 
   /**

--- a/test/user/application/user.service.spec.ts
+++ b/test/user/application/user.service.spec.ts
@@ -128,16 +128,16 @@ describe('UserService', () => {
   });
 
   describe('withdrawUser', () => {
-    it('prisma transaction 기반 유저를 소프트 delete 처리한다.', async () => {
+    it('prisma transaction 기반 사용자 정보를 삭제 처리한다.', async () => {
       const userId = 1;
 
       // 1. 각 repository의 메서드 mock
-      const softDeleteUserInTransaction = jest.fn();
+      const deleteById = jest.fn();
       const deleteManyToken = jest.fn();
       const deleteManyProfile = jest.fn();
 
       // 2. repository mock 메서드 주입
-      service['userRepository'].softDeleteUserInTransaction = softDeleteUserInTransaction;
+      service['userRepository'].deleteById = deleteById;
       service['tokenRepository'].deleteManyByUserId = deleteManyToken;
       service['profileRepository'].deleteManyByUserId = deleteManyProfile;
 
@@ -151,7 +151,7 @@ describe('UserService', () => {
       await expect(service.withdrawUser(userId)).resolves.toBeUndefined();
 
       // 6. 각 repository가 tx를 받아 호출됐는지 체크
-      expect(softDeleteUserInTransaction).toHaveBeenCalledWith(userId, mockTx);
+      expect(deleteById).toHaveBeenCalledWith(userId, mockTx);
       expect(deleteManyToken).toHaveBeenCalledWith(userId, mockTx);
       expect(deleteManyProfile).toHaveBeenCalledWith(userId, mockTx);
     });

--- a/test/user/infrastructure/user.repository.spec.ts
+++ b/test/user/infrastructure/user.repository.spec.ts
@@ -78,13 +78,15 @@ describe('UserRepository', () => {
         providerId: dto.providerId,
       };
 
+      const isNew = false;
+
       prismaService.user.findUnique.mockResolvedValue(expectedUser as User);
 
       // 2. when ( 실행 )
       const result = await repository.findOrCreateSocialUser(dto);
 
       // 3. then ( 검증 )
-      expect(result).toEqual(expectedUser);
+      expect(result).toEqual({ user: expectedUser, isNew });
       expect(prismaService.user.findUnique).toHaveBeenCalledWith({ where: { email: dto.email } });
       expect(prismaService.user.create).not.toHaveBeenCalled();
     });
@@ -105,6 +107,8 @@ describe('UserRepository', () => {
         providerId: dto.providerId,
       };
 
+      const isNew = true;
+
       // 사용자가 없다고 가정
       prismaService.user.findUnique.mockResolvedValue(null);
 
@@ -124,7 +128,7 @@ describe('UserRepository', () => {
           providerId: dto.providerId,
         },
       });
-      expect(result).toEqual(createdUser);
+      expect(result).toEqual({ user: createdUser, isNew });
     });
   });
 
@@ -213,6 +217,8 @@ describe('UserRepository', () => {
         name: 'existingUser',
       };
 
+      const isNew = false;
+
       const mockResult = createMockUser();
 
       prismaService.user.findUnique.mockResolvedValue(mockResult);
@@ -221,7 +227,7 @@ describe('UserRepository', () => {
       const result = await repository.findOrCreateLocalUser(dto);
 
       // 3. then
-      expect(result).toEqual(mockResult);
+      expect(result).toEqual({ user: mockResult, isNew });
       expect(prismaService.user.findUnique).toHaveBeenCalledWith({
         where: {
           email: dto.email,
@@ -236,6 +242,8 @@ describe('UserRepository', () => {
         password: 'password',
         name: 'newUser',
       };
+
+      const isNew = true;
 
       const mockResult = createMockUser();
 
@@ -259,7 +267,7 @@ describe('UserRepository', () => {
           password: expect.any(String),
         },
       });
-      expect(result).toEqual(mockResult);
+      expect(result).toEqual({ user: mockResult, isNew });
     });
   });
 });


### PR DESCRIPTION
## #️⃣연관된 이슈

> #38

## 📝작업 내용
- 로컬 & 소셜 최초 가입시 기본(default) 프로필을 생성하는 로직을 추가
- 로컬 & 소셜 사용자 조회&생성 로직의 반환 타입을 추가하여 application layer에서 최초 가입시 slackWebhook 호출과 프로필을 생성하는 로직을 분기 처리 
- 회원탈퇴시 softDelete 하던 방식을 일반 delete로 변경 
- 위의 수정 사항에 맞춰 기본 unit Test 케이스 수정 및 추가 