### PR TITLE
[#44] 메인 홈 피드 스키마 및 기본 엔터티 일괄 수정

### DIFF
--- a/src/feed/domain/value-object/section.vo.ts
+++ b/src/feed/domain/value-object/section.vo.ts
@@ -1,5 +1,6 @@
 export class Section {
   constructor(
+    public readonly restaurantId: string,
     public readonly storeName: string,
     public readonly description: string,
     public readonly summary: string,
@@ -7,11 +8,14 @@ export class Section {
     public readonly businessHours: string,
     public readonly menus: { name: string; price: string }[],
     public readonly imageUrls: string[],
+    public readonly latitude: number,
+    public readonly longitude: number,
   ) {}
 
   // 추후 어드민(admin)에서 사용할 수 있기 때문에 정적 생성자 메서드로 정의
   static create(props: SectionProps): Section {
     return new Section(
+      props.restaurantId,
       props.storeName,
       props.description,
       props.summary,
@@ -19,11 +23,14 @@ export class Section {
       props.businessHours,
       props.menus ?? [],
       props.imageUrls ?? [],
+      props.latitude,
+      props.longitude,
     );
   }
 }
 
 export interface SectionProps {
+  restaurantId: string;
   storeName: string;
   description: string;
   summary: string;
@@ -31,4 +38,6 @@ export interface SectionProps {
   businessHours: string;
   menus?: { name: string; price: string }[];
   imageUrls?: string[];
+  latitude?: number;
+  longitude?: number;
 }

--- a/src/feed/infrastructure/feed.schema.ts
+++ b/src/feed/infrastructure/feed.schema.ts
@@ -12,6 +12,7 @@ const MenuSchema = new Schema(
 // Section 서브스키마 (section1~section5 공통 구조)
 const SectionSchema = new Schema(
   {
+    restaurantId: { type: String, required: true },
     storeName: { type: String, required: true },
     description: { type: String, required: true },
     summary: { type: String, required: true },
@@ -19,6 +20,8 @@ const SectionSchema = new Schema(
     businessHours: { type: String, required: true },
     menus: { type: [MenuSchema], default: [] },
     imageUrls: { type: [String], default: [] },
+    latitude: { type: Number, required: true },
+    longitude: { type: Number, required: true },
   },
   { _id: false },
 );
@@ -38,6 +41,7 @@ export const FeedSchema = new Schema(
 );
 
 export interface SectionDocument {
+  restaurantId: string;
   storeName: string;
   description: string;
   summary: string;
@@ -45,6 +49,8 @@ export interface SectionDocument {
   businessHours: string;
   menus: { name: string; price: string }[];
   imageUrls: string[];
+  latitude: number;
+  longitude: number;
 }
 
 export interface FeedDocument extends Document {

--- a/src/feed/presentation/dto/response/feed.response.dto.ts
+++ b/src/feed/presentation/dto/response/feed.response.dto.ts
@@ -14,6 +14,10 @@ export class MenuDto {
 
 export class SectionDto {
   @Expose()
+  @ApiProperty({ description: '가게의 참조 Id', example: '68b952d78f23d69589331a66', type: String })
+  restaurantId: string;
+
+  @Expose()
   @ApiProperty({ description: '가게 이름', example: '한남동 맛집1', type: String })
   storeName: string;
 
@@ -51,6 +55,14 @@ export class SectionDto {
     example: ['https://example.com/image1.jpg', 'https://example.com/image2.jpg'],
   })
   imageUrls: string[];
+
+  @Expose()
+  @ApiProperty({ description: '가게의 위도', example: 37.559503986, type: Number })
+  latitude: number;
+
+  @Expose()
+  @ApiProperty({ description: '가게의 경도', example: 1127.005068637, type: Number })
+  longitude: number;
 }
 
 export class FeedResponseDto {
@@ -91,6 +103,7 @@ export class FeedResponseDto {
     dto.character = feed.getCharacter();
     dto.title = feed.getTitle();
     dto.sections = feed.getSections().map((section) => ({
+      restaurantId: section.restaurantId,
       storeName: section.storeName,
       description: section.description,
       summary: section.summary,
@@ -101,6 +114,8 @@ export class FeedResponseDto {
         price: m.price,
       })),
       imageUrls: section.imageUrls,
+      latitude: section.latitude,
+      longitude: section.longitude,
     }));
     return dto;
   }

--- a/test/__mocks__/feed.factory.ts
+++ b/test/__mocks__/feed.factory.ts
@@ -29,6 +29,7 @@ export class FeedFactory {
 
   static createSection(overrides: Partial<SectionProps> = {}): Section {
     const defaultProps: SectionProps = {
+      restaurantId: '68b952d78f23d69589331a66',
       storeName: 'Coffee Shop',
       description: 'A cozy coffee shop',
       summary: '맛있는 다이노스 음식점',
@@ -36,6 +37,8 @@ export class FeedFactory {
       businessHours: '09:00~10:00',
       menus: [{ name: 'Latte', price: '5.00' }],
       imageUrls: ['http://example.com/image.jpg'],
+      latitude: 37.123456,
+      longitude: 127.123456,
     };
 
     return Section.create({ ...defaultProps, ...overrides });


### PR DESCRIPTION
## #️⃣연관된 이슈

> #44 메인 홈 피드 schema 및 구조 변경

## 📝작업 내용

- schema 구조 변경 ( restaurantsId, latitude, longitude ) 값 추가 
- 각 VO, Mapper, DTO 수정
- unit test -> feed mock 데이터 수정  
