### PR TITLE
[#85] friendship-duplicate-friend-request

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -89,6 +89,9 @@ model Friendship {
   activities   FriendshipActivity[]
 
   // 제약 조건: 중복 친구 관계 방지
+  // !현재 constraint는 방향을 구분함 (requesterId=A,addresseeId=B) ≠ (requesterId=B,addresseeId=A)
+  // 완벽하게 방향 무관 중복 방지는 PostgreSQL expression index (LEAST/GREATEST) 가 필요하나,
+  // schema.prisma로 표현 불가 → 애플리케이션 레이어(requestFriendship, respondToFriendRequest)에서 방어하도록 임시 처리
   @@unique([requesterId, addresseeId], map: "unique_requester_addressee")
   @@index([requesterId], map: "idx_requester_id")
   @@index([addresseeId], map: "idx_addressee_id")

--- a/src/friendship/application/friendship.service.ts
+++ b/src/friendship/application/friendship.service.ts
@@ -1,4 +1,4 @@
-import { ForbiddenException, Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { ConflictException, ForbiddenException, Inject, Injectable, NotFoundException } from '@nestjs/common';
 import {
   FRIEND_REQUEST_REPOSITORY,
   FRIENDSHIP_ACTIVITY_REPOSITORY,
@@ -38,12 +38,23 @@ export class FriendshipService {
 
   /**
    * 친구요청 (상대방이 거절 했을 경우 다시 PENDING 상태로 Upsert)
+   * 역방향 PENDING 요청이 존재하면 ConflictException 반환 (Facebook 방식)
    * @param command  RequestFriendshipCommand
    * @returns FriendRequestEntity
    */
+  @Transactional()
   async requestFriendship(command: RequestFriendshipCommand): Promise<FriendRequestEntity> {
     const user = await this.userRepository.findByUserId(command.receiverId);
     if (!user) throw new NotFoundException(HttpFriendshipErrorConstants.NOT_FOUND_USER);
+
+    // 상대방이 이미 나에게 PENDING 요청을 보낸 경우 — 받은 요청을 수락하도록 유도
+    const reversePending = await this.friendRequestRepository.findPendingBySenderAndReceiver(
+      command.receiverId,
+      command.senderId,
+    );
+    if (reversePending) {
+      throw new ConflictException(HttpFriendshipErrorConstants.REVERSE_FRIEND_REQUEST_EXISTS);
+    }
 
     const friendRequest = FriendRequestEntity.create(command);
     return await this.friendRequestRepository.upsertRequestFriendInvite(friendRequest);
@@ -85,11 +96,18 @@ export class FriendshipService {
 
     // 사용자가 수락을 했을 경우에 친구 관계 테이블을 생성
     if (status === FriendRequestStatus.ACCEPTED) {
-      const entity = FriendshipEntity.create({
-        requesterId: findFriendRequest.senderId,
-        addresseeId: findFriendRequest.receiverId,
-      });
-      await this.friendshipRepository.upsertFriendship(entity);
+      // 동시 수락 race condition 방어: 이미 친구 관계가 존재하면 생성 생략 - 멱등성 보장
+      const existing = await this.friendshipRepository.findByUserPair(
+        findFriendRequest.senderId,
+        findFriendRequest.receiverId,
+      );
+      if (!existing) {
+        const entity = FriendshipEntity.create({
+          requesterId: findFriendRequest.senderId,
+          addresseeId: findFriendRequest.receiverId,
+        });
+        await this.friendshipRepository.upsertFriendship(entity);
+      }
     }
 
     return status === FriendRequestStatus.ACCEPTED ? '친구 요청을 수락하였습니다.' : '친구 요청을 거절하였습니다.';
@@ -106,40 +124,6 @@ export class FriendshipService {
     paginationOptions?: PaginationOptions,
   ): Promise<PaginatedResult<FriendWithActivityDto>> {
     return await this.friendshipQuery.findAllFriendship(userId, paginationOptions);
-
-    // const friendList = friendshipResult.data.map((friendship) => {
-    //   const friendInfo = friendship.getFriendInfo(userId);
-    //   const activityCount = friendship.activities.length || 0;
-
-    //   // 현재 사용자 기준으로 친구 정보 추출
-    //   const friendData = friendInfo.isRequester ? (friendship as any).addresseeInfo : (friendship as any).requesterInfo;
-
-    //   const profileData = friendData.profile
-    //     ? {
-    //         nickname: friendData.profile.nickname,
-    //         comment: friendData.profile.comment,
-    //         headerId: friendData.profile.headerId,
-    //         bodyId: friendData.profile.bodyId,
-    //         headerColor: friendData.profile.headerColor,
-    //         bodyColor: friendData.profile.bodyColor,
-    //       }
-    //     : null;
-
-    //   return FriendWithActivityDto.create({
-    //     id: friendship.id!,
-    //     friendUserId: friendInfo.friendId,
-    //     email: friendData.email,
-    //     name: friendData.name,
-    //     friendProfileData: profileData,
-    //     activityCount,
-    //     createdAt: friendship.createdAt!,
-    //   });
-    // });
-
-    // return {
-    //   data: friendList,
-    //   meta: friendshipResult.meta,
-    // };
   }
 
   /**

--- a/src/friendship/application/helper/http-error-object.ts
+++ b/src/friendship/application/helper/http-error-object.ts
@@ -41,4 +41,10 @@ export const HttpFriendshipErrorConstants = {
     error: 'FORBIDDEN_FRIENDSHIP_REMOVAL',
     message: '친구 관계를 제거할 권한이 없습니다.',
   } as HttpErrorFormat,
+
+  REVERSE_FRIEND_REQUEST_EXISTS: {
+    status: HttpStatus.CONFLICT,
+    error: 'REVERSE_FRIEND_REQUEST_EXISTS',
+    message: '상대방이 이미 친구 요청을 보냈습니다. 받은 요청을 확인해주세요.',
+  } as HttpErrorFormat,
 };

--- a/src/friendship/domain/repository/friend-request.repository.interface.ts
+++ b/src/friendship/domain/repository/friend-request.repository.interface.ts
@@ -2,6 +2,7 @@ import { FriendRequestEntity } from '../entities/friend-request.entity';
 
 export interface IFriendRequestRepository {
   findById(id: number): Promise<FriendRequestEntity | null>;
+  findPendingBySenderAndReceiver(senderId: number, receiverId: number): Promise<FriendRequestEntity | null>;
   upsertRequestFriendInvite(entity: FriendRequestEntity): Promise<FriendRequestEntity>;
   findByReceiveId(receiveId: number): Promise<FriendRequestEntity[]>;
   removeByReceiverAndSenderId(senderId: number, receiverId: number): Promise<void>;

--- a/src/friendship/domain/repository/friendship.repository.interface.ts
+++ b/src/friendship/domain/repository/friendship.repository.interface.ts
@@ -2,6 +2,7 @@ import { FriendshipEntity } from '../entities/friendship.entity';
 
 export interface IFriendshipRepository {
   findById(id: number): Promise<FriendshipEntity>;
+  findByUserPair(userIdA: number, userIdB: number): Promise<FriendshipEntity | null>;
   upsertFriendship(entity: FriendshipEntity): Promise<FriendshipEntity>;
   removeById(id: number): Promise<FriendshipEntity>;
 }

--- a/src/friendship/infrastructure/repository/friend-request.repository.ts
+++ b/src/friendship/infrastructure/repository/friend-request.repository.ts
@@ -67,6 +67,19 @@ export class FriendRequestRepository
   }
 
   /**
+   * 특정 방향의 PENDING 친구 요청 조회 (역방향 요청 존재 여부 체크용)
+   * @param senderId 요청을 보낸 사용자 ID
+   * @param receiverId 요청을 받은 사용자 ID
+   */
+  async findPendingBySenderAndReceiver(senderId: number, receiverId: number): Promise<FriendRequestEntity | null> {
+    const friendRequest = await this.model.findFirst({
+      where: { senderId, receiverId, status: FriendRequestStatus.PENDING },
+    });
+
+    return friendRequest ? FriendRequestMapper.toDomain(friendRequest) : null;
+  }
+
+  /**
    * receiverId와 senderId에 해당하는 친구 요청 기록 제거
    * @param receiverId
    * @param senderId

--- a/src/friendship/infrastructure/repository/friendship.repository.ts
+++ b/src/friendship/infrastructure/repository/friendship.repository.ts
@@ -17,6 +17,24 @@ export class FriendshipRepository
   }
 
   /**
+   * 두 사용자 간 친구 관계 조회 (방향 무관)
+   * @param userIdA
+   * @param userIdB
+   */
+  async findByUserPair(userIdA: number, userIdB: number): Promise<FriendshipEntity | null> {
+    const friendship = await this.model.findFirst({
+      where: {
+        OR: [
+          { requesterId: userIdA, addresseeId: userIdB },
+          { requesterId: userIdB, addresseeId: userIdA },
+        ],
+      },
+    });
+
+    return friendship ? FriendshipMapper.toDomain(friendship) : null;
+  }
+
+  /**
    * 친구 관계 테이블 Upsert
    * @param entity FriendshipEntity
    * @returns FriendshipEntity

--- a/src/friendship/presentation/swagger/rest-swagger.decorator.ts
+++ b/src/friendship/presentation/swagger/rest-swagger.decorator.ts
@@ -23,6 +23,7 @@ export const SendFriendRequestDocs = () => {
       - 친구 요청 전송 엔드포인트 
       - receiverId는 친구 요청을 받는 사용자의 userId 값이고, 이전에 사용자가 거절했던 이력이 있더라도 Pending(대기) 상태로 upsert 된다.
       - 본인이 본인에게 친구 요청을 보내면 400 에러를 반환한다.
+      - 상대방이 이미 나에게 PENDING 요청을 보낸 경우 409 에러를 반환한다.
       `,
     }),
     ApiBody({
@@ -40,6 +41,10 @@ export const SendFriendRequestDocs = () => {
       {
         status: StatusCodes.BAD_REQUEST,
         errorFormatList: [HttpFriendshipErrorConstants.SAME_USER_ID],
+      },
+      {
+        status: StatusCodes.CONFLICT,
+        errorFormatList: [HttpFriendshipErrorConstants.REVERSE_FRIEND_REQUEST_EXISTS],
       },
       {
         status: StatusCodes.UNAUTHORIZED,

--- a/test/friendship/application/friendship.service.spec.ts
+++ b/test/friendship/application/friendship.service.spec.ts
@@ -1,4 +1,4 @@
-import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { ConflictException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { mockDeep } from 'jest-mock-extended';
 
 import { FriendshipService } from 'src/friendship/application/friendship.service';
@@ -65,6 +65,7 @@ describe('FriendshipService', () => {
       });
 
       userRepository.findByUserId.mockResolvedValue(mockUser);
+      friendRequestRepository.findPendingBySenderAndReceiver.mockResolvedValue(null);
       friendRequestRepository.upsertRequestFriendInvite.mockResolvedValue(mockFriendRequest);
 
       // when
@@ -73,6 +74,10 @@ describe('FriendshipService', () => {
       // then
       expect(result).toEqual(mockFriendRequest);
       expect(userRepository.findByUserId).toHaveBeenCalledWith(mockCommand.receiverId);
+      expect(friendRequestRepository.findPendingBySenderAndReceiver).toHaveBeenCalledWith(
+        mockCommand.receiverId,
+        mockCommand.senderId,
+      );
       expect(friendRequestRepository.upsertRequestFriendInvite).toHaveBeenCalled();
     });
 
@@ -84,6 +89,26 @@ describe('FriendshipService', () => {
       await expect(service.requestFriendship(mockCommand)).rejects.toThrow(NotFoundException);
       await expect(service.requestFriendship(mockCommand)).rejects.toThrow(
         HttpFriendshipErrorConstants.NOT_FOUND_USER.message as string,
+      );
+      expect(friendRequestRepository.upsertRequestFriendInvite).not.toHaveBeenCalled();
+    });
+
+    it('상대방이 이미 나에게 PENDING 친구 요청을 보낸 경우 ConflictException을 발생시킨다.', async () => {
+      // given
+      const mockUser = createMockUserEntity({ id: 2 });
+      const reverseRequest = createMockFriendshipRequestEntity({
+        senderId: 2,
+        receiverId: 1,
+        status: FriendRequestStatus.PENDING,
+      });
+
+      userRepository.findByUserId.mockResolvedValue(mockUser);
+      friendRequestRepository.findPendingBySenderAndReceiver.mockResolvedValue(reverseRequest);
+
+      // when & then
+      await expect(service.requestFriendship(mockCommand)).rejects.toThrow(ConflictException);
+      await expect(service.requestFriendship(mockCommand)).rejects.toThrow(
+        HttpFriendshipErrorConstants.REVERSE_FRIEND_REQUEST_EXISTS.message as string,
       );
       expect(friendRequestRepository.upsertRequestFriendInvite).not.toHaveBeenCalled();
     });
@@ -135,6 +160,7 @@ describe('FriendshipService', () => {
 
       friendRequestRepository.findById.mockResolvedValue(mockFriendRequest);
       friendRequestRepository.upsertRequestFriendInvite.mockResolvedValue(mockFriendRequest);
+      friendshipRepository.findByUserPair.mockResolvedValue(null);
       friendshipRepository.upsertFriendship.mockResolvedValue(mockFriendship);
 
       // when
@@ -144,7 +170,37 @@ describe('FriendshipService', () => {
       expect(result).toBe('친구 요청을 수락하였습니다.');
       expect(friendRequestRepository.findById).toHaveBeenCalledWith(friendRequestId);
       expect(friendRequestRepository.upsertRequestFriendInvite).toHaveBeenCalled();
+      expect(friendshipRepository.findByUserPair).toHaveBeenCalledWith(
+        mockFriendRequest.senderId,
+        mockFriendRequest.receiverId,
+      );
       expect(friendshipRepository.upsertFriendship).toHaveBeenCalled();
+    });
+
+    it('동시 수락으로 이미 친구 관계가 존재하면 upsertFriendship을 호출하지 않는다.', async () => {
+      // given
+      const mockFriendRequest = createMockFriendshipRequestEntity({
+        id: friendRequestId,
+        senderId: 1,
+        receiverId: userId,
+        status: FriendRequestStatus.PENDING,
+      });
+      const existingFriendship = createMockFriendshipEntity({ requesterId: 1, addresseeId: userId });
+
+      friendRequestRepository.findById.mockResolvedValue(mockFriendRequest);
+      friendRequestRepository.upsertRequestFriendInvite.mockResolvedValue(mockFriendRequest);
+      friendshipRepository.findByUserPair.mockResolvedValue(existingFriendship);
+
+      // when
+      const result = await service.respondToFriendRequest(friendRequestId, FriendRequestStatus.ACCEPTED, userId);
+
+      // then
+      expect(result).toBe('친구 요청을 수락하였습니다.');
+      expect(friendshipRepository.findByUserPair).toHaveBeenCalledWith(
+        mockFriendRequest.senderId,
+        mockFriendRequest.receiverId,
+      );
+      expect(friendshipRepository.upsertFriendship).not.toHaveBeenCalled();
     });
 
     it('친구 요청을 거절하면 친구 관계가 생성되지 않는다.', async () => {

--- a/test/friendship/infrastructure/repository/friend-request.repository.spec.ts
+++ b/test/friendship/infrastructure/repository/friend-request.repository.spec.ts
@@ -102,6 +102,43 @@ describe('FriendRequestRepository', () => {
     });
   });
 
+  describe('findPendingBySenderAndReceiver', () => {
+    it('PENDING 상태의 역방향 요청이 존재하면 해당 엔티티를 반환한다.', async () => {
+      // 1. given
+      txHost.tx.friendRequest.findFirst.mockResolvedValue(friendRequestDataBaseEntity);
+
+      // 2. when
+      const result = await repository.findPendingBySenderAndReceiver(
+        friendRequestMockEntity.senderId,
+        friendRequestMockEntity.receiverId,
+      );
+
+      // 3. then
+      expect(txHost.tx.friendRequest.findFirst).toHaveBeenCalledWith({
+        where: {
+          senderId: friendRequestMockEntity.senderId,
+          receiverId: friendRequestMockEntity.receiverId,
+          status: DomainFriendRequestStatus.PENDING,
+        },
+      });
+      expect(result).toEqual(FriendRequestMapper.toDomain(friendRequestDataBaseEntity));
+    });
+
+    it('PENDING 상태의 역방향 요청이 없으면 null을 반환한다.', async () => {
+      // 1. given
+      txHost.tx.friendRequest.findFirst.mockResolvedValue(null);
+
+      // 2. when
+      const result = await repository.findPendingBySenderAndReceiver(
+        friendRequestMockEntity.senderId,
+        friendRequestMockEntity.receiverId,
+      );
+
+      // 3. then
+      expect(result).toBeNull();
+    });
+  });
+
   describe('findByReceiveId', () => {
     it('나에게 요청을 보낸 친구 요청 정보와 상대방 프로필을 조회한다.', async () => {
       // 1.given

--- a/test/friendship/infrastructure/repository/friendship.repository.spec.ts
+++ b/test/friendship/infrastructure/repository/friendship.repository.spec.ts
@@ -36,6 +36,66 @@ describe('FriendshipRepository', () => {
     jest.clearAllMocks();
   });
 
+  describe('findByUserPair', () => {
+    it('requesterId→addresseeId 방향으로 친구 관계를 조회한다.', async () => {
+      // 1. given
+      txHost.tx.friendship.findFirst.mockResolvedValue(friendshipDataBaseEntity);
+
+      // 2. when
+      const result = await repository.findByUserPair(
+        friendshipMockEntity.requesterId,
+        friendshipMockEntity.addresseeId,
+      );
+
+      // 3. then
+      expect(txHost.tx.friendship.findFirst).toHaveBeenCalledWith({
+        where: {
+          OR: [
+            { requesterId: friendshipMockEntity.requesterId, addresseeId: friendshipMockEntity.addresseeId },
+            { requesterId: friendshipMockEntity.addresseeId, addresseeId: friendshipMockEntity.requesterId },
+          ],
+        },
+      });
+      expect(result).toEqual(FriendshipMapper.toDomain(friendshipDataBaseEntity));
+    });
+
+    it('addresseeId→requesterId 역방향으로도 친구 관계를 조회한다.', async () => {
+      // 1. given
+      txHost.tx.friendship.findFirst.mockResolvedValue(friendshipDataBaseEntity);
+
+      // 2. when
+      const result = await repository.findByUserPair(
+        friendshipMockEntity.addresseeId,
+        friendshipMockEntity.requesterId,
+      );
+
+      // 3. then
+      expect(txHost.tx.friendship.findFirst).toHaveBeenCalledWith({
+        where: {
+          OR: [
+            { requesterId: friendshipMockEntity.addresseeId, addresseeId: friendshipMockEntity.requesterId },
+            { requesterId: friendshipMockEntity.requesterId, addresseeId: friendshipMockEntity.addresseeId },
+          ],
+        },
+      });
+      expect(result).toEqual(FriendshipMapper.toDomain(friendshipDataBaseEntity));
+    });
+
+    it('친구 관계가 존재하지 않으면 null을 반환한다.', async () => {
+      // 1. given
+      txHost.tx.friendship.findFirst.mockResolvedValue(null);
+
+      // 2. when
+      const result = await repository.findByUserPair(
+        friendshipMockEntity.requesterId,
+        friendshipMockEntity.addresseeId,
+      );
+
+      // 3. then
+      expect(result).toBeNull();
+    });
+  });
+
   describe('upsertFriendship', () => {
     it('친구관계 테이블에 requesterId와 addresseeId가 존재하지 않을 경우 생성한다.', async () => {
       // 1. given


### PR DESCRIPTION
## #️⃣연관된 이슈

> #85

## ⚠️ ISSUE
- 친구 A가 B에게, B가 A에게 각각 친구 요청을 보낸 뒤, 둘 다 수락하면 친구 목록에 동일인이 2명 이상 노출됨 -> racecondition


## 📝작업 내용
- requestFriendship 비즈니스 로직에 트랜잭션 어노테이션 추가 및 역방향 Pending 방어로직 추가
- 친구 수락전 비즈니스 로직에서 수락전 친구 존재 체크
- unit test 추가 
