### PR TITLE
[#103] 닉네임 자동 생성 로직 한국어 기반으로 변경

### DIFF
--- a/src/user/application/helper/profile.factory.ts
+++ b/src/user/application/helper/profile.factory.ts
@@ -1,9 +1,45 @@
 import { UserProfileCommand } from '../command/user-profile.command';
 
 const generatenickname = (): string => {
-  const adjectives = ['happy', 'lazy', 'blue', 'fuzzy', 'quick'];
-  const animals = ['dino', 'cat', 'fox', 'panda', 'lion'];
-  const nickname = `${adjectives[Math.floor(Math.random() * adjectives.length)]}-${animals[Math.floor(Math.random() * animals.length)]}-${Math.floor(Math.random() * 1000)}`;
+  const adjectives = [
+    '행복한',
+    '느긋한',
+    '파란',
+    '푹신한',
+    '빠른',
+    '귀여운',
+    '용감한',
+    '신나는',
+    '졸린',
+    '배고픈',
+    '차가운',
+    '따뜻한',
+    '조용한',
+    '엉뚱한',
+    '수줍은',
+    '활발한',
+    '포근한',
+    '의젓한',
+  ];
+  const animals = [
+    '공룡',
+    '고양이',
+    '여우',
+    '판다',
+    '사자',
+    '토끼',
+    '펭귄',
+    '다람쥐',
+    '강아지',
+    '햄스터',
+    '기린',
+    '코끼리',
+    '오리',
+    '수달',
+    '늑대',
+    '양',
+  ];
+  const nickname = `${adjectives[Math.floor(Math.random() * adjectives.length)]}${animals[Math.floor(Math.random() * animals.length)]}${Math.floor(Math.random() * 1000)}`;
   return nickname.substring(0, 20); // 최대 20자 제한
 };
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #103

## 📝작업 내용
- profile.factory.ts의 영어 형용사/동물 배열을 한국어로 전환
- 형용사 18개, 동물 16개로 목록 확장하여 닉네임 다양성 개선