### PR TITLE
[#105] 내 프로필 조회 시 soft delete된 리뷰가 카운트에 포함되는 버그 수정

### DIFF
--- a/src/user/infrastructure/query/user.query.ts
+++ b/src/user/infrastructure/query/user.query.ts
@@ -29,7 +29,9 @@ export class UserQuery implements IUserQuery {
                 receivedFriendRequests: {
                   where: { status: 'PENDING' },
                 },
-                reviews: true,
+                reviews: {
+                  where: { deletedAt: null },
+                },
                 friendshipsAsRequester: true,
                 friendshipsAsAddressee: true,
               },


### PR DESCRIPTION
## #️⃣연관된 이슈

> #105

## 📝작업 내용
- user.query.ts의 _count.reviews 쿼리에 where: { deletedAt: null } 필터 추가하여 soft delete된 리뷰가 카운트에서 제외되도록 수정