### PR TITLE
[#107] catch 블록 error 타입 unknown 처리 개선

### DIFF
--- a/src/auth/application/auth.service.ts
+++ b/src/auth/application/auth.service.ts
@@ -8,6 +8,7 @@ import {
 } from '@nestjs/common';
 
 import { ConfigService } from '@nestjs/config';
+import { getErrorStack } from 'src/common/utils/error.util';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 
 import { JwtService, JwtSignOptions } from '@nestjs/jwt';
@@ -150,7 +151,7 @@ export class AuthService {
 
       return { accessToken, refreshToken };
     } catch (err) {
-      this.logger.error('로컬 로그인 처리 중 오류 발생', err.stack);
+      this.logger.error('로컬 로그인 처리 중 오류 발생', getErrorStack(err));
       if (err instanceof ConflictException) {
         throw err;
       }
@@ -256,7 +257,7 @@ export class AuthService {
           : this.configService.get<string>('ACCESS_SECRET'),
       });
     } catch (error) {
-      this.logger.error('토큰 검증 오류', error.stack);
+      this.logger.error('토큰 검증 오류', getErrorStack(error));
       if (error.name === 'TokenExpiredError') {
         // 토큰 만료 핸들링
         throw new UnauthorizedException(HttpErrorConstants.EXPIRED_TOKEN);

--- a/src/auth/infrastructure/strategy/apple.strategy.ts
+++ b/src/auth/infrastructure/strategy/apple.strategy.ts
@@ -9,6 +9,7 @@ import { HttpErrorConstants } from 'src/common/http/http-error-objects';
 import { OAuthPayLoad } from 'src/auth/domain/interface/token-payload.interface';
 
 import { WinstonLoggerService } from 'src/infrastructure/logger/winston-logger.service';
+import { getErrorStack } from 'src/common/utils/error.util';
 import { Provider } from 'src/user/domain/const/provider.enum';
 
 interface AppleJwtPayload {
@@ -87,7 +88,7 @@ export class AppleStrategy extends PassportStrategy(Strategy, 'apple') {
 
       return oauthPayload;
     } catch (err) {
-      this.logger.error('Apple token validation error', err.stack);
+      this.logger.error('Apple token validation error', getErrorStack(err));
       throw new InternalServerErrorException(HttpErrorConstants.SOCIAL_TOKEN_INTERNAL_SERVER_ERROR);
     }
   }

--- a/src/auth/infrastructure/strategy/google.strategy.ts
+++ b/src/auth/infrastructure/strategy/google.strategy.ts
@@ -8,6 +8,7 @@ import { HttpErrorConstants } from 'src/common/http/http-error-objects';
 import { OAuthPayLoad } from 'src/auth/domain/interface/token-payload.interface';
 import { Provider } from 'src/user/domain/const/provider.enum';
 import { WinstonLoggerService } from 'src/infrastructure/logger/winston-logger.service';
+import { getErrorStack } from 'src/common/utils/error.util';
 
 @Injectable()
 export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
@@ -40,7 +41,7 @@ export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
 
       return payload;
     } catch (err) {
-      this.logger.error('Google OAuth 검증 오류', err.stack);
+      this.logger.error('Google OAuth 검증 오류', getErrorStack(err));
       throw new InternalServerErrorException(HttpErrorConstants.SOCIAL_TOKEN_INTERNAL_SERVER_ERROR);
     }
   }

--- a/src/auth/infrastructure/strategy/jwt.strategy.ts
+++ b/src/auth/infrastructure/strategy/jwt.strategy.ts
@@ -4,6 +4,7 @@ import { ExtractJwt, Strategy } from 'passport-jwt';
 import { ConfigService } from '@nestjs/config';
 import { HttpErrorConstants } from 'src/common/http/http-error-objects';
 import { WinstonLoggerService } from 'src/infrastructure/logger/winston-logger.service';
+import { getErrorStack } from 'src/common/utils/error.util';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy, 'auth') {
@@ -22,7 +23,7 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'auth') {
     try {
       return payload;
     } catch (err) {
-      this.logger.error('JWT 토큰 검증 오류', err.stack);
+      this.logger.error('JWT 토큰 검증 오류', getErrorStack(err));
       throw new InternalServerErrorException(HttpErrorConstants.INTERNAL_SERVER_ERROR);
     }
   }

--- a/src/auth/infrastructure/strategy/naver.strategy.ts
+++ b/src/auth/infrastructure/strategy/naver.strategy.ts
@@ -8,6 +8,7 @@ import { HttpErrorConstants } from 'src/common/http/http-error-objects';
 import { OAuthPayLoad } from 'src/auth/domain/interface/token-payload.interface';
 import { Provider } from 'src/user/domain/const/provider.enum';
 import { WinstonLoggerService } from 'src/infrastructure/logger/winston-logger.service';
+import { getErrorStack } from 'src/common/utils/error.util';
 
 @Injectable()
 export class NaverStrategy extends PassportStrategy(Strategy, 'naver') {
@@ -49,7 +50,7 @@ export class NaverStrategy extends PassportStrategy(Strategy, 'naver') {
       };
       return payload;
     } catch (err) {
-      this.logger.error('Naver OAuth 검증 오류', err.stack);
+      this.logger.error('Naver OAuth 검증 오류', getErrorStack(err));
       throw new InternalServerErrorException(HttpErrorConstants.SOCIAL_TOKEN_INTERNAL_SERVER_ERROR);
     }
   }

--- a/src/common/utils/error.util.ts
+++ b/src/common/utils/error.util.ts
@@ -1,0 +1,12 @@
+export function toError(value: unknown): Error {
+  if (value instanceof Error) return value;
+  return new Error(String(value));
+}
+
+export function getErrorMessage(value: unknown): string {
+  return toError(value).message;
+}
+
+export function getErrorStack(value: unknown): string | undefined {
+  return toError(value).stack;
+}

--- a/src/infrastructure/event/listener/user-notification.listener.ts
+++ b/src/infrastructure/event/listener/user-notification.listener.ts
@@ -3,6 +3,7 @@ import { OnEvent } from '@nestjs/event-emitter';
 import { SlackService } from 'src/infrastructure/slack/slack.service';
 import { SERVICE_CHANNEL } from 'src/infrastructure/slack/constant/channel.const';
 import { WinstonLoggerService } from 'src/infrastructure/logger/winston-logger.service';
+import { getErrorStack } from 'src/common/utils/error.util';
 import { UserRegisteredEvent } from 'src/auth/application/event/user-registered.event';
 
 @Injectable()
@@ -23,7 +24,7 @@ export class UserNotificationListener {
 
       this.logger.log(`[사용자 등록 알림] ${event.email} - Slack 알림 전송 완료`);
     } catch (error) {
-      this.logger.error(`[사용자 등록 알림 실패] ${event.email}`, error);
+      this.logger.error(`[사용자 등록 알림 실패] ${event.email}`, getErrorStack(error));
     }
   }
 }

--- a/src/infrastructure/r2/r2.service.ts
+++ b/src/infrastructure/r2/r2.service.ts
@@ -7,6 +7,7 @@ import { v4 as Uuid } from 'uuid';
 import { HttpErrorConstants } from 'src/common/http/http-error-objects';
 import { IFileUploadService, PresignedUrlParams } from 'src/common/interface/file-upload.interface';
 import { WinstonLoggerService } from '../logger/winston-logger.service';
+import { getErrorMessage } from 'src/common/utils/error.util';
 import { PresignedUrlResponseDto } from 'src/common/dto/presigned-url.response.dto';
 
 @Injectable()
@@ -60,7 +61,7 @@ export class R2Service implements IFileUploadService {
         cdnUrl: this.getCdnUrl(key),
       };
     } catch (err) {
-      this.logger.error(`Failed to create presigned url: ${err.message}`);
+      this.logger.error(`Failed to create presigned url: ${getErrorMessage(err)}`);
       throw new InternalServerErrorException(HttpErrorConstants.INTERNAL_SERVER_ERROR);
     }
   }

--- a/src/infrastructure/slack/slack.service.ts
+++ b/src/infrastructure/slack/slack.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { WebClient } from '@slack/web-api';
 import { WinstonLoggerService } from 'src/infrastructure/logger/winston-logger.service';
+import { getErrorMessage, getErrorStack } from 'src/common/utils/error.util';
 
 @Injectable()
 export class SlackService {
@@ -27,7 +28,7 @@ export class SlackService {
       });
       this.logger.log(`Slack message sent to ${channel}: ${text}`);
     } catch (error) {
-      this.logger.error(`Failed to send Slack message to ${channel}: ${error.message}`, error.stack);
+      this.logger.error(`Failed to send Slack message to ${channel}: ${getErrorMessage(error)}`, getErrorStack(error));
       throw error;
     }
   }
@@ -50,7 +51,7 @@ export class SlackService {
       await this.webClient.chat.postMessage(message);
       this.logger.log(`Error notification sent to Slack channel: ${channel}`);
     } catch (slackError) {
-      this.logger.error(`Failed to send Slack notification: ${slackError.message}`);
+      this.logger.error(`Failed to send Slack notification: ${getErrorMessage(slackError)}`);
     }
   }
 }

--- a/src/pin/application/pin.service.ts
+++ b/src/pin/application/pin.service.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable, InternalServerErrorException } from '@nestjs/common';
 import { PIN_QUERY_REPOSITORY, PIN_REPOSITORY, RESTAURANT_REPOSITORY } from 'src/common/config/common.const';
+import { getErrorMessage, getErrorStack } from 'src/common/utils/error.util';
 import { IPinRepository } from '../domain/repository/pin.repository.interface';
 import { IRestaurantRepository } from 'src/restaurant/domain/repository/restaurant.repository.interface';
 import { TogglePinCommand } from './command/toggle-pin.command';
@@ -65,7 +66,7 @@ export class PinService {
       const created = await this.pinRepository.create(pinEntity);
       return { pin: created, action: 'created' };
     } catch (error) {
-      this.logger.error(error.message, error.stack);
+      this.logger.error(getErrorMessage(error), getErrorStack(error));
       throw new InternalServerErrorException(HttpErrorConstants.INTERNAL_SERVER_ERROR);
     }
   }

--- a/src/review/application/review.service.ts
+++ b/src/review/application/review.service.ts
@@ -24,6 +24,7 @@ import { ReviewQuestionOptionEntity } from '../domain/entities/review-question-o
 import { Transactional } from '@nestjs-cls/transactional';
 import { HttpErrorConstants } from 'src/common/http/http-error-objects';
 import { WinstonLoggerService } from 'src/infrastructure/logger/winston-logger.service';
+import { getErrorMessage, getErrorStack } from 'src/common/utils/error.util';
 import { IReviewQuery } from './interface/review-query.interface';
 import { ReviewStep } from '../domain/const/review.enum';
 import { ReviewQuestionWithOptionsEntity } from '../domain/entities/review-question-with-options.entity';
@@ -223,7 +224,7 @@ export class ReviewService {
 
       return CreateReviewResponseDto.fromEntity(review);
     } catch (error) {
-      this.logger.error(error.message, error.stack);
+      this.logger.error(getErrorMessage(error), getErrorStack(error));
       throw new InternalServerErrorException(HttpErrorConstants.INTERNAL_SERVER_ERROR);
     }
   }
@@ -265,7 +266,7 @@ export class ReviewService {
       //? 3. 질문과 선택지를 함께 저장
       return await this.reviewQuestionRepository.createWithOptions(questionEntity, optionEntities);
     } catch (error) {
-      this.logger.error(error.message, error.stack);
+      this.logger.error(getErrorMessage(error), getErrorStack(error));
       throw new InternalServerErrorException(HttpErrorConstants.INTERNAL_SERVER_ERROR);
     }
   }
@@ -288,7 +289,7 @@ export class ReviewService {
 
       return createdQuestions;
     } catch (error) {
-      this.logger.error(error.message, error.stack);
+      this.logger.error(getErrorMessage(error), getErrorStack(error));
       throw new InternalServerErrorException(HttpErrorConstants.INTERNAL_SERVER_ERROR);
     }
   }

--- a/src/user/application/user.service.ts
+++ b/src/user/application/user.service.ts
@@ -1,6 +1,7 @@
 import { ConflictException, Inject, Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
 import { WinstonLoggerService } from 'src/infrastructure/logger/winston-logger.service';
 import { HttpErrorConstants } from 'src/common/http/http-error-objects';
+import { getErrorStack } from 'src/common/utils/error.util';
 import { HttpUserErrorConstants } from './helper/http-error-object';
 
 import {
@@ -93,7 +94,7 @@ export class UserService {
       await this.tokenRepository.deleteManyByUserId(userId);
       await this.profileRepository.deleteManyByUserId(userId);
     } catch (err) {
-      this.logger.error('회원탈퇴 트랜잭션 오류', err.stack);
+      this.logger.error('회원탈퇴 트랜잭션 오류', getErrorStack(err));
       throw new InternalServerErrorException(HttpErrorConstants.INTERNAL_SERVER_ERROR);
     }
   }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #107

## 📝작업 내용
- src/common/utils/error.util.ts 공통 유틸 생성 (toError, getErrorMessage, getErrorStack)
- auth, review, pin, user, slack, r2 등 12개 파일 catch 블록 전체 적용