### PR TITLE
build: 툴체인 버전 고정 (Node 24.16.0 LTS + pnpm 11.7.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # -----------------------------------------------
 # Stage 1: Dependencies
 # -----------------------------------------------
-FROM node:22-alpine AS deps
+FROM node:24.16.0-alpine AS deps
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
@@ -20,7 +20,7 @@ RUN pnpm install --frozen-lockfile
 # -----------------------------------------------
 # Stage 2: Builder
 # -----------------------------------------------
-FROM node:22-alpine AS builder
+FROM node:24.16.0-alpine AS builder
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
@@ -46,7 +46,7 @@ RUN pnpm prune --prod --ignore-scripts
 # -----------------------------------------------
 # Stage 3: Runner (Production)
 # -----------------------------------------------
-FROM node:22-alpine AS runner
+FROM node:24.16.0-alpine AS runner
 
 WORKDIR /app
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,11 @@
   "author": "esyeol",
   "private": true,
   "license": "MIT",
+  "packageManager": "pnpm@11.7.0",
+  "engines": {
+    "node": ">=24 <25",
+    "pnpm": ">=11 <12"
+  },
   "scripts": {
     "build": "NODE_ENV=production nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
@@ -23,7 +28,7 @@
     "test:feed": "jest --testPathPattern=test/feed",
     "test:friendship": "jest --testPathPattern=test/friendship",
     "test:bookmark": "jest --testPathPattern=test/bookmark",
-    "prepare": "husky"
+    "prepare": "husky || true"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.726.1",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,5 +9,7 @@ allowBuilds:
   "@scarf/scarf": false
   "@sentry-internal/node-cpu-profiler": true
   bcrypt: true
+  cpu-features: false
   prisma: true
   protobufjs: true
+  ssh2: false


### PR DESCRIPTION
## 배경
`deploy.sh` 빌드가 `pnpm install --frozen-lockfile`에서 `ERR_PNPM_IGNORED_BUILDS`로 실패(exit 1). 원인은 ① pnpm 버전 미고정(corepack이 최신 pnpm 10/11을 끌어옴) ② `pnpm-workspace.yaml`의 `allowBuilds`에서 `cpu-features`/`ssh2`가 미결 플레이스홀더로 남아 pnpm 10+의 빌드스크립트 차단이 빌드를 실패시킴.

Closes #125

## 변경
- **Dockerfile**: `node:22-alpine` → `node:24.16.0-alpine` (deps/builder/runner 3스테이지). 최신 LTS(Krypton).
- **package.json**: `packageManager: "pnpm@11.7.0"` 고정 + `engines`(node `>=24 <25`, pnpm `>=11 <12`). corepack이 어디서나 동일 pnpm 사용 → 버전 드리프트 방지.
- **pnpm-workspace.yaml**: `allowBuilds`의 `cpu-features`/`ssh2` → `false` (네이티브 빌드 불필요, alpine 빌드툴 부재). `ERR_PNPM_IGNORED_BUILDS` 근본 해소.
- **prepare**: `husky` → `husky || true` (Docker `.git` 부재 대비).

## 검증
Docker와 동일한 `pnpm install --frozen-lockfile`을 pnpm 11.7.0으로 로컬 실행 → exit 0, IGNORED_BUILDS 0건. lockfile 변동 없음(frozen 호환).

## 영향
- 이후 corepack은 항상 pnpm 11.7.0, Node 24.16.0 사용 → 빌드 회귀 방지.
- 머지 후 서버 `deploy.sh`가 dinos-backend를 pull → 새 툴체인으로 재빌드.