### PR TITLE
[#130] 프론트엔드 화면 연결을 위한 Swagger API 문서 일괄 정비

### DIFF
--- a/src/auth/presentation/swagger/rest-swagger.decorator.ts
+++ b/src/auth/presentation/swagger/rest-swagger.decorator.ts
@@ -14,12 +14,13 @@ import { CreateUserDto } from 'src/user/presentation/dto/request/create-user.dto
 export const SocialLoginDocs = () => {
   return applyDecorators(
     ApiOperation({
-      summary: '소셜 가입 및 로그인 인증 ',
-      description: `
-      - 소셜 플랫폼 유형별로 회원가입 및 로그인 검증 완료후 Access, Refresh Token을 발행한다.
-      - email은 unique 하며, 플랫폼 별로 email 값이 같을 경우 중복 가입을 방지한다.
-      - conflict exception이 발생할 경우, 프론트엔드에서 다른 플랫폼에 가입된 정보로 바로 로그인을 시켜주던가, 화면 or 모달에서 별도로 표기해주어야한다.
-      `,
+      summary: '소셜 가입 및 로그인 인증 ( Login/Signin )',
+      description: [
+        '- 소셜 플랫폼 유형별로 회원가입 및 로그인 검증 완료후 Access, Refresh Token을 발행한다.',
+        '- email은 unique 하며, 플랫폼 별로 email 값이 같을 경우 중복 가입을 방지한다.',
+        '- conflict exception이 발생할 경우, 프론트엔드에서 다른 플랫폼에 가입된 정보로 바로 로그인을 시켜주던가, 화면 or 모달에서 별도로 표기해주어야한다.',
+        '- 프론트 화면: [ 참고 (Figma)](https://www.figma.com/design/AtU0tCeeJ6GKP0M7X3fFO0/%EB%8B%A4%EC%9D%B4%EB%85%B8%EC%8A%A4-%EA%B0%9C%EB%B0%9C?node-id=201-12482&t=6ZVA1CPvQqHzL8mH-0)',
+      ].join('\n'),
     }),
     ApiBody({
       type: SocialLoginDto,
@@ -58,14 +59,15 @@ export const SocialLoginDocs = () => {
 export const LocalLoginDocs = () => {
   return applyDecorators(
     ApiOperation({
-      summary: '자체 가입 및 로그인 인증 ',
-      description: `
-      - 자체 플랫폼 (Email)로 회원가입 및 로그인 검증 완료후 Access, Refresh Token을 발행한다.
-      - email은 unique 하며, 플랫폼 별로 email 값이 같을 경우 중복 가입을 방지한다.
-      - conflict exception이 발생할 경우, 프론트엔드에서 다른 플랫폼에 가입된 정보로 바로 로그인을 시켜주던가, 화면 or 모달에서 별도로 표기해주어야한다.
-      - 비밀번호는 영문, 숫자, 특수문자 조합 8자 이상으로 정의 -> 정확하게 입력을 하지 않을 경우 400 Validation Error Response
-      - 이름은 Nullable -> 회원가입 & 로그인에 대응되어 처리하기 위함.
-      `,
+      summary: '자체 가입 및 로그인 인증 ( Login/Signin )',
+      description: [
+        '- 자체 플랫폼 (Email)로 회원가입 및 로그인 검증 완료후 Access, Refresh Token을 발행한다. ( 현재는 테스트 용도로 사용 프로덕션에서는 사용 x)',
+        '- email은 unique 하며, 플랫폼 별로 email 값이 같을 경우 중복 가입을 방지한다.',
+        '- conflict exception이 발생할 경우, 프론트엔드에서 다른 플랫폼에 가입된 정보로 바로 로그인을 시켜주던가, 화면 or 모달에서 별도로 표기해주어야한다.',
+        '- 비밀번호는 영문, 숫자, 특수문자 조합 8자 이상으로 정의 -> 정확하게 입력을 하지 않을 경우 400 Validation Error Response',
+        '- 이름은 Nullable -> 회원가입 & 로그인에 대응되어 처리하기 위함.',
+        '- 프론트 화면: [ 참고 (Figma)](https://www.figma.com/design/AtU0tCeeJ6GKP0M7X3fFO0/%EB%8B%A4%EC%9D%B4%EB%85%B8%EC%8A%A4-%EA%B0%9C%EB%B0%9C?node-id=201-12482&t=6ZVA1CPvQqHzL8mH-0)',
+      ].join('\n'),
     }),
     ApiBody({
       type: CreateUserDto,
@@ -97,9 +99,10 @@ export const RotateAccessTokenDocs = () => {
   return applyDecorators(
     ApiOperation({
       summary: '엑세스 토큰 재발급',
-      description: `
-      - 리프레시 토큰으로 엑세스 토큰을 재발급한다.
-      - 검증 절차(1. Bearer 여부,  2. Refresh 형태,  3. Token Signature,  4. RefToken 테이블에 정상적으로 등록된 토큰인지 여부) `,
+      description: [
+        '- 리프레시 토큰으로 엑세스 토큰을 재발급한다.',
+        '- 검증 절차(1. Bearer 여부,  2. Refresh 형태,  3. Token Signature,  4. RefToken 테이블에 정상적으로 등록된 토큰인지 여부)',
+      ].join('\n'),
     }),
     ApiHeader({
       name: 'authorization',
@@ -128,12 +131,13 @@ export const LogOutDocs = () => {
   return applyDecorators(
     ApiBearerAuth(),
     ApiOperation({
-      summary: '로그아웃',
-      description: `
-      - 헤더에 authorization key로 Bearer AccessToken을 요청 
-      - 응답 성공시 204 noContent를 반환한다 
-      - 웹은 고려하지 않고 있기 때문에, 자체 RN에서 AsyncStorage에서 토큰을 제거
-      `,
+      summary: '로그아웃 ( Mypage > Logout )',
+      description: [
+        '- 헤더에 authorization key로 Bearer AccessToken을 요청',
+        '- 응답 성공시 204 noContent를 반환한다',
+        '- 웹은 고려하지 않고 있기 때문에, 자체 RN에서 AsyncStorage에서 토큰을 제거',
+        '- 프론트 화면: [ 참고 (Figma)](https://www.figma.com/design/AtU0tCeeJ6GKP0M7X3fFO0/%EB%8B%A4%EC%9D%B4%EB%85%B8%EC%8A%A4-%EA%B0%9C%EB%B0%9C?node-id=201-6941&t=6ZVA1CPvQqHzL8mH-0)',
+      ].join('\n'),
     }),
     ApiNoContentResponseTemplate({
       description: '로그아웃 성공',

--- a/src/bookmark/presentation/bookmark.controller.ts
+++ b/src/bookmark/presentation/bookmark.controller.ts
@@ -12,7 +12,7 @@ import { ItemType } from '../domain/const/item-type.enum';
 import { PaginatedBookmarkResponseDto } from './dto/response/response.bookmark.dto';
 import { PaginationQueryDto } from 'src/common/dto/pagination.dto';
 
-@ApiTags('Bookmarks - 북마크')
+@ApiTags('Bookmarks - 북마크 ( Deprecated > 미사용 api )')
 @ApiBearerAuth()
 @ApiCommonErrorResponseTemplate()
 @Controller('bookmarks')

--- a/src/bookmark/presentation/swagger/rest-swagger.decorator.ts
+++ b/src/bookmark/presentation/swagger/rest-swagger.decorator.ts
@@ -14,10 +14,12 @@ export const ToggleBookmarkDocs = () => {
   return applyDecorators(
     ApiOperation({
       summary: '북마크 생성 또는 제거 ( toggle )',
-      description: `북마크를 생성 또는 제거 ( toggle ) 한다.
-      - 북마크가 존재할 경우 제거하고, 존재하지 않을 경우 생성한다.
-      - 북마크 조회 시, 북마크 존재 여부를 확인하고, 존재할 경우 제거하고, 존재하지 않을 경우 생성한다.
-      `,
+      description: [
+        '북마크를 생성 또는 제거 ( toggle ) 한다.',
+        '',
+        '- 북마크가 존재할 경우 제거하고, 존재하지 않을 경우 생성한다.',
+        '- 북마크 조회 시, 북마크 존재 여부를 확인하고, 존재할 경우 제거하고, 존재하지 않을 경우 생성한다.',
+      ].join('\n'),
     }),
     ApiBody({
       type: ToggleBookmarkDto,
@@ -44,11 +46,13 @@ export const FindFilterBookmarkDocs = () => {
   return applyDecorators(
     ApiOperation({
       summary: '내가 북마크한 피드 및 음식점 조회 ( 페이징 처리 )',
-      description: `내가 북마크한 피드 및 음식점을 조회한다.
-      - 페이징 처리를 위해 page와 limit를 받을 수 있고, 기본값은 page=1, limit=20이다.
-      - itemType을 통해 피드 및 음식점을 구분한다.
-      - 내가 북마크한 데이터가 없을경우 response의 data값이 빈 배열로 리스폰스 된다.
-      `,
+      description: [
+        '내가 북마크한 피드 및 음식점을 조회한다.',
+        '',
+        '- 페이징 처리를 위해 page와 limit를 받을 수 있고, 기본값은 page=1, limit=20이다.',
+        '- itemType을 통해 피드 및 음식점을 구분한다.',
+        '- 내가 북마크한 데이터가 없을경우 response의 data값이 빈 배열로 리스폰스 된다.',
+      ].join('\n'),
     }),
     ApiQuery({
       name: 'page',

--- a/src/feed/presentation/feed.controller.ts
+++ b/src/feed/presentation/feed.controller.ts
@@ -9,7 +9,7 @@ import { FindAllFeedDocs, FindByHomeFeedDocs, FindByIdFeedDocs } from './swagger
 import { FeedResponseDto } from './dto/response/feed.response.dto';
 import { HttpFeedErrorConstants } from '../application/helper/http-error-object';
 
-@ApiTags('Feed - 피드')
+@ApiTags('Feed - 피드 ( Deprecated > 미사용 api )')
 @ApiCommonErrorResponseTemplate()
 @Controller('feeds')
 export class FeedController {

--- a/src/feed/presentation/swagger/rest-swagger.decorator.ts
+++ b/src/feed/presentation/swagger/rest-swagger.decorator.ts
@@ -14,11 +14,11 @@ export const FindAllFeedDocs = () => {
   return applyDecorators(
     ApiOperation({
       summary: `전체 홈 피드의 Documents 리스트 조회`,
-      description: `
-          - 전체 홈 피드에 대한 MongoDB의 Documents 리스트를 조회한다.
-          - 실제 Application 개발이 아닌 추후, Admin 환경에서 적용된다.
-          - Public API로 설정되어 있어, 인증 없이 접근 가능하다.
-          `,
+      description: [
+        '- 전체 홈 피드에 대한 MongoDB의 Documents 리스트를 조회한다.',
+        '- 실제 Application 개발이 아닌 추후, Admin 환경에서 적용된다.',
+        '- Public API로 설정되어 있어, 인증 없이 접근 가능하다.',
+      ].join('\n'),
     }),
     ApiOkResponseTemplate({
       description: '전체 홈 피드 조회 성공',
@@ -33,10 +33,10 @@ export const FindByHomeFeedDocs = () => {
     ApiBearerAuth(),
     ApiOperation({
       summary: `홈 피드 조회`,
-      description: `
-          - 크롤링된 InputKeyWord 기반 AI로 생성된 홈 피드를 조회한다.
-          - 실제 배포되는 Application Home Feeds 메인에서 조회되는 리스트다.
-          `,
+      description: [
+        '- 크롤링된 InputKeyWord 기반 AI로 생성된 홈 피드를 조회한다.',
+        '- 실제 배포되는 Application Home Feeds 메인에서 조회되는 리스트다.',
+      ].join('\n'),
     }),
     ApiOkResponseTemplate({
       description: '홈 피드 조회 성공',
@@ -57,10 +57,10 @@ export const FindByIdFeedDocs = () => {
     ApiBearerAuth(),
     ApiOperation({
       summary: `ID 기반 피드 상세 조회`,
-      description: `
-          - ID를 기반으로 피드의 상세 정보를 조회한다.
-          - 만약, 해당 ID로 피드를 찾을 수 없는 경우, NotFoundException이 발생한다.
-          `,
+      description: [
+        '- ID를 기반으로 피드의 상세 정보를 조회한다.',
+        '- 만약, 해당 ID로 피드를 찾을 수 없는 경우, NotFoundException이 발생한다.',
+      ].join('\n'),
     }),
     ApiParam({
       name: 'id',

--- a/src/friendship/presentation/swagger/rest-swagger.decorator.ts
+++ b/src/friendship/presentation/swagger/rest-swagger.decorator.ts
@@ -18,13 +18,14 @@ import { SharedPinsResponseDto } from '../dto/response/shared-pins.response.dto'
 export const SendFriendRequestDocs = () => {
   return applyDecorators(
     ApiOperation({
-      summary: '친구 요청 전송',
-      description: `
-      - 친구 요청 전송 엔드포인트 
-      - receiverId는 친구 요청을 받는 사용자의 userId 값이고, 이전에 사용자가 거절했던 이력이 있더라도 Pending(대기) 상태로 upsert 된다.
-      - 본인이 본인에게 친구 요청을 보내면 400 에러를 반환한다.
-      - 상대방이 이미 나에게 PENDING 요청을 보낸 경우 409 에러를 반환한다.
-      `,
+      summary: '친구 요청 전송 ( Mypage > 친구 > 친구 추가 )',
+      description: [
+        '- 친구 요청 전송 엔드포인트',
+        '- receiverId는 친구 요청을 받는 사용자의 userId 값이고, 이전에 사용자가 거절했던 이력이 있더라도 Pending(대기) 상태로 upsert 된다.',
+        '- 본인이 본인에게 친구 요청을 보내면 400 에러를 반환한다.',
+        '- 상대방이 이미 나에게 PENDING 요청을 보낸 경우 409 에러를 반환한다.',
+        '- 프론트 화면: [화면 (Figma)](https://www.figma.com/design/AtU0tCeeJ6GKP0M7X3fFO0/%EB%8B%A4%EC%9D%B4%EB%85%B8%EC%8A%A4-%EA%B0%9C%EB%B0%9C?node-id=201-6911&t=zRtKYhIbdF799Dtl-0)',
+      ].join('\n'),
     }),
     ApiBody({
       type: SendFriendRequestDto,
@@ -58,11 +59,12 @@ export const SendFriendRequestDocs = () => {
 export const FindByReceiveIdDocs = () => {
   return applyDecorators(
     ApiOperation({
-      summary: '나에게 요청을 보낸 유저 정보 조회',
-      description: `
-      - 나에게 요청을 보낸 유저 정보를 조회한다.
-      - 요청을 보낸 사용자가 없을 경우 빈 배열을 리턴한다.
-      `,
+      summary: '나에게 요청을 보낸 유저 정보 조회 ( Mypage > 친구 > 친구 추가 > 요청 목록 )',
+      description: [
+        '- 나에게 요청을 보낸 유저 정보를 조회한다.',
+        '- 요청을 보낸 사용자가 없을 경우 빈 배열을 리턴한다.',
+        '- 프론트 화면: [화면 (Figma)](https://www.figma.com/design/AtU0tCeeJ6GKP0M7X3fFO0/%EB%8B%A4%EC%9D%B4%EB%85%B8%EC%8A%A4-%EA%B0%9C%EB%B0%9C?node-id=201-6922&t=zRtKYhIbdF799Dtl-0)',
+      ].join('\n'),
     }),
     ApiOkResponseTemplate({
       description: '나에게 요청을 보낸 유저 정보 조회 성공',
@@ -82,16 +84,17 @@ export const FindByReceiveIdDocs = () => {
 export const RespondToFriendRequestDocs = () => {
   return applyDecorators(
     ApiOperation({
-      summary: '친구 요청에 대한 사용자의 응답을 처리하는 엔드포인트',
-      description: `
-      - 상대방이 나에게 보낸 친구 요청을 수락(ACCEPTED) 또는 거절(REJECTED) 하기 위한 엔드포인트
-      - 사용자의 Bearer Token의 user 정보를 기반으로 본인에게 온 요청인지 체크 후 403 에러를 반환
-      - 친구 요청 id값이 불일치 하면 404 에러를 반환 
-      - 사용자가 친구 요청을 수락(ACCEPTED) 또는 거절(REJECTED) 하면 친구 관계 테이블을 생성 또는 미생성한다. 
-      - 거절 (REJECTED) 했을 경우, 기존 친구 요청 테이블에서 상태값이 REJECTED로 업데이트 되고, 나의 요청 목록에서 제거된다.
-      - 친구 요청을 수락(ACCEPTED)시, http response의 result로 "친구 요청을 수락하였습니다." 
-      - 친구 요청을 거절(REJECTED)시, http response의 result로 "친구 요청을 거절하였습니다."
-      `,
+      summary: '친구 요청에 대한 사용자의 응답을 처리하는 엔드포인트 ( Mypage > 친구 > 요청 목록 ( 확인 | 삭제 ))',
+      description: [
+        '- 상대방이 나에게 보낸 친구 요청을 수락(ACCEPTED) 또는 거절(REJECTED) 하기 위한 엔드포인트',
+        '- 사용자의 Bearer Token의 user 정보를 기반으로 본인에게 온 요청인지 체크 후 403 에러를 반환',
+        '- 친구 요청 id값이 불일치 하면 404 에러를 반환',
+        '- 사용자가 친구 요청을 수락(ACCEPTED) 또는 거절(REJECTED) 하면 친구 관계 테이블을 생성 또는 미생성한다.',
+        '- 거절 (REJECTED) 했을 경우, 기존 친구 요청 테이블에서 상태값이 REJECTED로 업데이트 되고, 나의 요청 목록에서 제거된다.',
+        '- 친구 요청을 수락(ACCEPTED)시, http response의 result로 "친구 요청을 수락하였습니다."',
+        '- 친구 요청을 거절(REJECTED)시, http response의 result로 "친구 요청을 거절하였습니다."',
+        '- 프론트 화면: [화면 (Figma)](https://www.figma.com/design/AtU0tCeeJ6GKP0M7X3fFO0/%EB%8B%A4%EC%9D%B4%EB%85%B8%EC%8A%A4-%EA%B0%9C%EB%B0%9C?node-id=201-6922&t=zRtKYhIbdF799Dtl-0)',
+      ].join('\n'),
     }),
     ApiParam({
       description: '친구 요청 id ( 내가 받은 친구요청 리스트를 조회 했을 때의 id ) ',
@@ -128,12 +131,13 @@ export const RespondToFriendRequestDocs = () => {
 export const FindAllFriendshipDocs = () => {
   return applyDecorators(
     ApiOperation({
-      summary: '나의 친구 리스트 조회',
-      description: `
-      - 나의 친구 리스트를 조회한다.
-      - 친구 리스트는 친구의 사용자(userId) ID, 이메일, 이름, 프로필 정보, 활동 수, 생성 시간을 포함한다.
-      - query 파라미터로 page와 limit를 받을 수 있고, 기본값은 page=1, limit=20이다.
-      `,
+      summary: '나의 친구 리스트 조회 ( Mypage > 친구 ( 목록 ) )',
+      description: [
+        '- 나의 친구 리스트를 조회한다.',
+        '- 친구 리스트는 친구의 사용자(userId) ID, 이메일, 이름, 프로필 정보, 활동 수, 생성 시간을 포함한다.',
+        '- query 파라미터로 page와 limit를 받을 수 있고, 기본값은 page=1, limit=20이다.',
+        '- 프론트 화면: [화면 (Figma)](https://www.figma.com/design/AtU0tCeeJ6GKP0M7X3fFO0/%EB%8B%A4%EC%9D%B4%EB%85%B8%EC%8A%A4-%EA%B0%9C%EB%B0%9C?node-id=201-6343&t=XfzYONie16XC3WuL-0)',
+      ].join('\n'),
     }),
     ApiQuery({
       name: 'page',
@@ -164,13 +168,14 @@ export const FindAllFriendshipDocs = () => {
 export const FindSharedPinsDocs = () => {
   return applyDecorators(
     ApiOperation({
-      summary: '나와 같은 음식점을 pin한 친구 조회 (shared-pins)',
-      description: `
-      - 내가 pin한 음식점 중 나와 친구인 사용자도 동일하게 pin한 음식점과 해당 친구 프로필 목록을 반환한다.
-      - 음식점을 기준으로 그루핑되어 반환된다.
-      - 공유된 pin이 없으면 빈 배열을 반환한다.
-      - ! 내가 pin한 리소스가 아무리 많더라도 친구와 겹치는 리소스는 한정적일 수 있기에 현재는 페이징 및 리소스 튜닝은 하지 않고 반환된다. ( 추후 리소스 튜닝은 필요 )
-      `,
+      summary: '나와 같은 음식점을 pin한 친구 조회 ( Home > 나와 같은 곳 저장한 친구 목록 ) ',
+      description: [
+        '- 내가 pin한 음식점 중 나와 친구인 사용자도 동일하게 pin한 음식점과 해당 친구 프로필 목록을 반환한다.',
+        '- 음식점을 기준으로 그루핑되어 반환된다.',
+        '- 공유된 pin이 없으면 빈 배열을 반환한다.',
+        '- ! 내가 pin한 리소스가 아무리 많더라도 친구와 겹치는 리소스는 한정적일 수 있기에 현재는 페이징 및 리소스 튜닝은 하지 않고 반환된다. ( 추후 리소스 튜닝은 필요 )',
+        '- 프론트 화면: [화면 (Figma)](https://www.figma.com/design/AtU0tCeeJ6GKP0M7X3fFO0/%EB%8B%A4%EC%9D%B4%EB%85%B8%EC%8A%A4-%EA%B0%9C%EB%B0%9C?node-id=201-190&t=XfzYONie16XC3WuL-0)',
+      ].join('\n'),
     }),
     ApiOkResponseTemplate({
       description: 'shared-pins 조회 성공',
@@ -190,13 +195,14 @@ export const FindSharedPinsDocs = () => {
 export const RemoveFriendshipDocs = () => {
   return applyDecorators(
     ApiOperation({
-      summary: '친구 제거',
-      description: `
-      - 친구를 제거한다.
-      - 친구 관계를 제거할 권한이 없으면 403 에러를 반환한다(Bearer Token의 user 정보를 기반으로 본인의 친구 관계가 아닌 경우)
-      - 친구 관계를 찾을 수 없으면 404 에러를 반환한다. 
-      - 친구를 제거하면 친구 요청, 활동 내역, 친구 관계 정보가 모두 일괄로 hard delete 된다.
-      `,
+      summary: '친구 제거 ( Mypage > 친구 목록 제거 )',
+      description: [
+        '- 친구를 제거한다.',
+        '- 친구 관계를 제거할 권한이 없으면 403 에러를 반환한다(Bearer Token의 user 정보를 기반으로 본인의 친구 관계가 아닌 경우)',
+        '- 친구 관계를 찾을 수 없으면 404 에러를 반환한다.',
+        '- 친구를 제거하면 친구 요청, 활동 내역, 친구 관계 정보가 모두 일괄로 hard delete 된다.',
+        '- 프론트 화면: [화면 (Figma)](https://www.figma.com/design/AtU0tCeeJ6GKP0M7X3fFO0/%EB%8B%A4%EC%9D%B4%EB%85%B8%EC%8A%A4-%EA%B0%9C%EB%B0%9C?node-id=201-6397&t=zRtKYhIbdF799Dtl-0)',
+      ].join('\n'),
     }),
     ApiParam({
       description: '친구 관계 id',

--- a/src/pin/presentation/swagger/rest-swagger.decorator.ts
+++ b/src/pin/presentation/swagger/rest-swagger.decorator.ts
@@ -13,13 +13,13 @@ import { NearbyPinResponseDto } from '../dto/response/nearby-pins.response.dto';
 export const TogglePinDocs = () => {
   return applyDecorators(
     ApiOperation({
-      summary: '핀 생성 또는 제거 ( toggle )',
-      description: `
-      - 핀을 생성 또는 제거 ( toggle ) 한다.
-      - 핀이 존재할 경우 제거하고, 존재하지 않을 경우 생성한다.
-      - 본인이 가고자 하는 PLANNED 타입의 핀을 생성한다. (deprecated)
-      - VISITED 유형의 핀은 해당 API로 생성되는 것이 아니라, Review 생성시 자동으로 해당 pin의 type이 VISITED로 UPSERT 된다. (deprecated)
-      `,
+      summary: '핀 생성 또는 제거 ( Map > 핀 토글 ) ',
+      description: [
+        '- 핀을 생성 또는 제거 ( toggle ) 한다.',
+        '- 핀이 존재할 경우 제거하고, 존재하지 않을 경우 생성한다.',
+        '- 본인이 가고자 하는 PLANNED 타입의 핀을 생성한다. (deprecated)',
+        '- VISITED 유형의 핀은 해당 API로 생성되는 것이 아니라, Review 생성시 자동으로 해당 pin의 type이 VISITED로 UPSERT 된다. (deprecated)',
+      ].join('\n'),
     }),
     ApiBody({
       type: TogglePinDto,
@@ -41,15 +41,14 @@ export const TogglePinDocs = () => {
 export const NearbyPinsDocs = () => {
   return applyDecorators(
     ApiOperation({
-      summary: '주변 핀 조회',
-      description: `
-      - 사용자 디바이스의 위치 정보 (위도&경도) 값을 기준으로 본인이 pin 한 음식점 리스트를 일괄로 조회한다. 
-      - 프론트엔드에서는 요청을 보낼 때, min & max 위도 경도 값을 함께 보내주어야 한다 
-        - 여기서 말하는 min & max 위도 경도 값은 프론트엔드의 화면 비율의 최소 위도 경도 값과 최대 위도 경도 값을 의미한다 ( Naver Map 기준 )
-      - limit 값을 통해 조회할 핀의 개수를 제한할 수 있다. ( 기본값: 50, 최대: 1000 )
-      - type 값을 통해 조회할 핀의 타입별로 필터링 할 수 있다. type을 전달하지 않을 경우, 모든 타입의 핀을 조회한다.  ( deprecated )
-      - 사용자가 핀한 리스트가 없을 경우 빈 배열을 반환한다.  ( deprecated )
-      `,
+      summary: '주변 내가 핀한 가게 조회 ( MAP > 핀 )',
+      description: [
+        '- 사용자 디바이스의 위치 정보 (위도&경도) 값을 기준으로 본인이 pin 한 음식점 리스트를 일괄로 조회한다.',
+        '- 프론트엔드에서는 요청을 보낼 때, min & max 위도 경도 값을 함께 보내주어야 한다.',
+        '- 여기서 말하는 min & max 위도 경도 값은 프론트엔드의 화면 비율의 최소/최대 위도 경도 값을 의미한다. ( Naver Map 기준 )',
+        '- limit 값을 통해 조회할 핀의 개수를 제한할 수 있다. ( 기본값: 50, 최대: 1000 )',
+        '- 프론트 화면: [Map / Search 화면 (Figma)](https://figma.com/file/xxx?node-id=123)',
+      ].join('\n'),
     }),
     ApiOkResponseTemplate({
       description: '주변 핀 조회 성공',

--- a/src/recommendation/presentation/swagger/rest-swagger.decorator.ts
+++ b/src/recommendation/presentation/swagger/rest-swagger.decorator.ts
@@ -10,15 +10,16 @@ export const GetMyRecommendationsDocs = () => {
   return applyDecorators(
     ApiOperation({
       summary: '개별 유저 추천 식당 조회',
-      description: `
-      - ML 배치가 사전 계산한 사용자 맞춤 추천 식당 목록을 반환한다.
-      - 기본 정렬: score 내림차순, 최대 10개 반환.
-      - category 필터 적용 시 해당 카테고리 식당만 반환한다.
-      - distance 필터 적용 시 latitude, longitude 는 필수이다. (lat, lon 값을 보내지 않으면 400에러 반환 )
-        - nearest: 반경 제한 없이 가까운순 정렬
-        - 100 / 500 / 1000 / 3000 / 5000: 해당 반경(m) 이내 필터 + 가까운순 정렬
-      - 추천 데이터가 없는 경우 (신규 유저 등) 빈 배열을 반환한다.
-      `,
+      description: [
+        '- ML 배치가 사전 계산한 사용자 맞춤 추천 식당 목록을 반환한다.',
+        '- 기본 정렬: score 내림차순, 최대 10개 반환.',
+        '- category 필터 적용 시 해당 카테고리 식당만 반환한다.',
+        '- distance 필터 적용 시 latitude, longitude 는 필수이다. (lat, lon 값을 보내지 않으면 400에러 반환 )',
+        '  - nearest: 반경 제한 없이 가까운순 정렬',
+        '  - 100 / 500 / 1000 / 3000 / 5000: 해당 반경(m) 이내 필터 + 가까운순 정렬',
+        '- 추천 데이터가 없는 경우 (신규 유저 등) 빈 배열을 반환한다.',
+        '- 프론트 화면: [화면 (Figma)](https://www.figma.com/design/AtU0tCeeJ6GKP0M7X3fFO0/%EB%8B%A4%EC%9D%B4%EB%85%B8%EC%8A%A4-%EA%B0%9C%EB%B0%9C?node-id=201-273&t=zRtKYhIbdF799Dtl-0)',
+      ].join('\n'),
     }),
     ApiOkResponseTemplate({
       description: '개인화 추천 식당 조회 성공',

--- a/src/restaurant/presentation/swagger/rest-swagger.decorator.ts
+++ b/src/restaurant/presentation/swagger/rest-swagger.decorator.ts
@@ -11,14 +11,16 @@ export const SearchRestaurantDocs = () => {
   return applyDecorators(
     ApiOperation({
       summary: '사용자 좌표 기반 음식점 키워드 검색 - ( Map > Search )',
-      description: `
-      - 사용자 현재 위치 또는 지도 중심 좌표를 기준으로 지정 반경 안에서 음식점을 검색한다. ( 앱에서 사용자 현재 좌표 값 기반으로 좌표를 요청 )
-      - 가게명 부분일치로 후보를 추리고, 정확일치/전방일치를 우선한 뒤 거리순으로 정렬한다.
-      - 내부적으로는 반경의 외접 bbox로 후보를 먼저 좁혀 latitude/longitude 인덱스를 활용한다.
-      - limit 값으로 조회 개수를 제한한다. ( 기본값: 50, 최대: 100 )
-      - keyword가 비어있거나 공백뿐이면 400을 반환한다.
-      - 검색 결과가 없을 경우 빈 배열을 반환한다.
-      `,
+      description: [
+        '- 사용자 현재 위치 또는 지도 중심 좌표를 기준으로 지정 반경 안에서 음식점을 검색한다. ( 앱에서 사용자 현재 좌표 값 기반으로 좌표를 요청 )',
+        '- 가게명 부분일치로 후보를 추리고, 정확일치/전방일치를 우선한 뒤 거리순으로 정렬한다.',
+        '- 내부적으로는 반경의 외접 bbox로 후보를 먼저 좁혀 latitude/longitude 인덱스를 활용한다.',
+        '- limit 값으로 조회 개수를 제한한다. ( 기본값: 50, 최대: 100 )',
+        '- keyword가 비어있거나 공백뿐이면 400을 반환한다.',
+        '- 검색 결과가 없을 경우 빈 배열을 반환한다.',
+        '- 현재 검색 기록은 백단에서 관리하지 않음',
+        '- 프론트 화면: [화면 (Figma)](https://www.figma.com/design/AtU0tCeeJ6GKP0M7X3fFO0/%EB%8B%A4%EC%9D%B4%EB%85%B8%EC%8A%A4-%EA%B0%9C%EB%B0%9C?node-id=201-4049&t=zRtKYhIbdF799Dtl-0)',
+      ].join('\n'),
     }),
     ApiOkResponseTemplate({
       description: '지도 영역 키워드 검색 성공',

--- a/src/review/presentation/swagger/rest-swagger.decorator.ts
+++ b/src/review/presentation/swagger/rest-swagger.decorator.ts
@@ -27,14 +27,15 @@ export const CreateReviewDocs = () => {
   return applyDecorators(
     ApiOperation({
       summary: '리뷰 작성',
-      description: `
-      - 가게에 대한 리뷰를 작성한다.
-      - 가게 정보(name, address)를 기반으로 자동 upsert 처리된다. (Naver Place 기반)
-      - answers는 선택사항이며, 각 항목은 optionId 또는 customAnswer 중 하나만 입력해야 한다.
-      - reviews/questions 에서 반환된 Questions의 id는 모두 포함시켜야 한다. (추후 리뷰를 수정하는 케이스에서 해당 질문지를 그대로 보여주어야 하기 때문)
-      - images는 선택사항이며, 첨부 시 isPrimary: true 항목이 반드시 1개여야 한다.
-      - WRAP_UP 단계 답변은 필수이며, 최소 1개 이상 답변을 제출해야 한다.
-      `,
+      description: [
+        '- 가게에 대한 리뷰를 작성한다.',
+        '- 가게 정보(name, address)를 기반으로 자동 upsert 처리된다. (Naver Place 기반)',
+        '- answers는 선택사항이며, 각 항목은 optionId 또는 customAnswer 중 하나만 입력해야 한다.',
+        '- reviews/questions 에서 반환된 Questions의 id는 모두 포함시켜야 한다. (추후 리뷰를 수정하는 케이스에서 해당 질문지를 그대로 보여주어야 하기 때문)',
+        '- images는 선택사항이며, 첨부 시 isPrimary: true 항목이 반드시 1개여야 한다.',
+        '- WRAP_UP 단계 답변은 필수이며, 최소 1개 이상 답변을 제출해야 한다.',
+        '- 프론트 화면: [화면 (Figma)](https://www.figma.com/design/AtU0tCeeJ6GKP0M7X3fFO0/%EB%8B%A4%EC%9D%B4%EB%85%B8%EC%8A%A4-%EA%B0%9C%EB%B0%9C?node-id=201-5944&t=zRtKYhIbdF799Dtl-0)',
+      ].join('\n'),
     }),
     ApiBody({ type: CreateReviewDto }),
     ApiCreatedResponseTemplate({
@@ -59,14 +60,15 @@ export const GetMyReviewsDocs = () => {
   return applyDecorators(
     ApiOperation({
       summary: '내가 작성한 리뷰 목록 조회',
-      description: `
-      - 사용자가 작성한 리뷰 목록을 최신순으로 반환한다.
-      - 커서 기반 페이징(30개)으로 동작한다.
-      - 첫 요청 시 cursor 파라미터를 생략한다.
-      - 응답의 nextCursor 값을 다음 요청의 cursor 파라미터로 전달하면 다음 페이지를 조회할 수 있다.
-      - hasNext가 false이면 마지막 페이지이다.
-      - 각 리뷰에는 가게 이름/주소, 답변(질문 텍스트 포함), 이미지 목록이 포함된다.
-      `,
+      description: [
+        '- 사용자가 작성한 리뷰 목록을 최신순으로 반환한다.',
+        '- 커서 기반 페이징(30개)으로 동작한다.',
+        '- 첫 요청 시 cursor 파라미터를 생략한다.',
+        '- 응답의 nextCursor 값을 다음 요청의 cursor 파라미터로 전달하면 다음 페이지를 조회할 수 있다.',
+        '- hasNext가 false이면 마지막 페이지이다.',
+        '- 각 리뷰에는 가게 이름/주소, 답변(질문 텍스트 포함), 이미지 목록이 포함된다.',
+        '- 프론트 화면: [화면 (Figma)](https://www.figma.com/design/AtU0tCeeJ6GKP0M7X3fFO0/%EB%8B%A4%EC%9D%B4%EB%85%B8%EC%8A%A4-%EA%B0%9C%EB%B0%9C?node-id=201-4232&t=zRtKYhIbdF799Dtl-0)',
+      ].join('\n'),
     }),
     ApiCursorPaginatedOkResponse({
       description: '내 리뷰 목록 조회 성공',
@@ -86,10 +88,11 @@ export const DeleteReviewDocs = () => {
   return applyDecorators(
     ApiOperation({
       summary: '리뷰 삭제',
-      description: `
-      - 리뷰를 소프트 삭제 처리한다.
-      - 본인 리뷰가 아니거나 존재하지 않는 경우 404를 반환한다.
-      `,
+      description: [
+        '- 리뷰를 소프트 삭제 처리한다.',
+        '- 본인 리뷰가 아니거나 존재하지 않는 경우 404를 반환한다.',
+        '- 프론트 화면: [화면 (Figma)](https://www.figma.com/design/AtU0tCeeJ6GKP0M7X3fFO0/%EB%8B%A4%EC%9D%B4%EB%85%B8%EC%8A%A4-%EA%B0%9C%EB%B0%9C?node-id=201-4726&t=zRtKYhIbdF799Dtl-0)',
+      ].join('\n'),
     }),
     ApiNoContentResponseTemplate({ description: '리뷰 삭제 성공' }),
     ApiErrorResponseTemplate([
@@ -110,13 +113,14 @@ export const UpdateReviewDocs = () => {
   return applyDecorators(
     ApiOperation({
       summary: '리뷰 수정',
-      description: `
-      - 리뷰를 수정한다.
-      - 본인 리뷰가 아니거나 존재하지 않는 경우 404를 반환한다.
-      - answers, images는 제공 시 기존 데이터를 전체 교체한다. 생략 시 기존 데이터를 유지한다.
-      - 수정을 완료하면 최종적으로 수정 완료된 리소스를 반환한다. 
-      - WRAP_UP 단계 답변은 필수이며, 최소 1개 이상 답변을 제출해야 한다.
-      `,
+      description: [
+        '- 리뷰를 수정한다.',
+        '- 본인 리뷰가 아니거나 존재하지 않는 경우 404를 반환한다.',
+        '- answers, images는 제공 시 기존 데이터를 전체 교체한다. 생략 시 기존 데이터를 유지한다.',
+        '- 수정을 완료하면 최종적으로 수정 완료된 리소스를 반환한다.',
+        '- WRAP_UP 단계 답변은 필수이며, 최소 1개 이상 답변을 제출해야 한다.',
+        '- 프론트 화면: [화면 (Figma)](https://www.figma.com/design/AtU0tCeeJ6GKP0M7X3fFO0/%EB%8B%A4%EC%9D%B4%EB%85%B8%EC%8A%A4-%EA%B0%9C%EB%B0%9C?node-id=201-5759&t=zRtKYhIbdF799Dtl-0)',
+      ].join('\n'),
     }),
     ApiBody({ type: UpdateReviewDto }),
     ApiOkResponseTemplate({
@@ -145,12 +149,13 @@ export const GetReviewDetailDocs = () => {
   return applyDecorators(
     ApiOperation({
       summary: '리뷰 단건 상세 조회 (수정 화면 진입용)',
-      description: `
-      - 리뷰 수정 화면 진입 시 호출
-      - 작성 당시 보여줬던 질문과 선택지 전체를 그대로 반환한다. ( 기존 최초 접근시 랜덤으로 뿌려주는 방식 X )
-      - 각 step의 userAnswer는 사용자가 이전에 선택한 답변이며, skip한 항목은 optionId, customAnswer 모두 null로 반환된다.
-      - 본인 리뷰가 아니거나 존재하지 않는 경우 404를 반환한다.
-      `,
+      description: [
+        '- 리뷰 수정 화면 진입 시 호출',
+        '- 작성 당시 보여줬던 질문과 선택지 전체를 그대로 반환한다. ( 기존 최초 접근시 랜덤으로 뿌려주는 방식 X )',
+        '- 각 step의 userAnswer는 사용자가 이전에 선택한 답변이며, skip한 항목은 optionId, customAnswer 모두 null로 반환된다.',
+        '- 본인 리뷰가 아니거나 존재하지 않는 경우 404를 반환한다.',
+        '- 프론트 화면: [화면 (Figma)](https://www.figma.com/design/AtU0tCeeJ6GKP0M7X3fFO0/%EB%8B%A4%EC%9D%B4%EB%85%B8%EC%8A%A4-%EA%B0%9C%EB%B0%9C?node-id=201-5578&t=zRtKYhIbdF799Dtl-0)',
+      ].join('\n'),
     }),
     ApiOkResponseTemplate({
       description: '리뷰 상세 조회 성공',
@@ -174,11 +179,12 @@ export const GetReviewFormQuestionsDocs = () => {
   return applyDecorators(
     ApiOperation({
       summary: '리뷰 폼 질문 조회',
-      description: `
-      - 리뷰 작성 시 각 단계(step)에 표시할 질문을 반환한다.
-      - 총 5단계(BEFORE_ENTRY, ENTRY, ORDER, MEAL, WRAP_UP)에 대해 각 1개씩 랜덤으로 선택된다.
-      - 특정 단계에 활성화된 질문이 없을 경우 해당 step의 question은 null로 반환된다 ( 해당 부분은 관리자단에서 잘 못 리소스를 삽입한 부분이기 때문에 임시 처리용으로 처리 )
-      `,
+      description: [
+        '- 리뷰 작성 시 각 단계(step)에 표시할 질문을 반환한다.',
+        '- 총 5단계(BEFORE_ENTRY, ENTRY, ORDER, MEAL, WRAP_UP)에 대해 각 1개씩 랜덤으로 선택된다.',
+        '- 특정 단계에 활성화된 질문이 없을 경우 해당 step의 question은 null로 반환된다 ( 해당 부분은 관리자단에서 잘 못 리소스를 삽입한 부분이기 때문에 임시 처리용으로 처리 )',
+        '- 프론트 화면: [화면 (Figma)](https://www.figma.com/design/AtU0tCeeJ6GKP0M7X3fFO0/%EB%8B%A4%EC%9D%B4%EB%85%B8%EC%8A%A4-%EA%B0%9C%EB%B0%9C?node-id=201-6087&t=zRtKYhIbdF799Dtl-0)',
+      ].join('\n'),
     }),
     ApiOkResponseTemplate({
       description: '리뷰 폼 질문 조회 성공',
@@ -198,13 +204,14 @@ export const GetPresignedUrlDocs = () => {
   return applyDecorators(
     ApiOperation({
       summary: '단일 presigned url 발급',
-      description: `
-      - 단일 presigned url 발급을 요청한다.
-      - 발급된 presigned url은 프론트에서 이용 가능하며 PUT 메서드로 해당 PresignedURL에 요청을 보내야 한다. 
-      - 요청을 보낼 때, DTO 요청값 (filename, size, mimeType)은 원본 파일과 동일한 정보를 기반으로 요청을 보내야 한다. (요청 받은 이미지의 메타 정보와 불일치할 경우 업로드 실패)
-      - 업로드 완료 후 경로값을 백단으로 보내기 위한 cdn url도 함께 발급된다.
-      - 발급된 presigned url은 1시간 동안 유효하다.
-      `,
+      description: [
+        '- 단일 presigned url 발급을 요청한다.',
+        '- 발급된 presigned url은 프론트에서 이용 가능하며 PUT 메서드로 해당 PresignedURL에 요청을 보내야 한다.',
+        '- 요청을 보낼 때, DTO 요청값 (filename, size, mimeType)은 원본 파일과 동일한 정보를 기반으로 요청을 보내야 한다. (요청 받은 이미지의 메타 정보와 불일치할 경우 업로드 실패)',
+        '- 업로드 완료 후 경로값을 백단으로 보내기 위한 cdn url도 함께 발급된다.',
+        '- 발급된 presigned url은 1시간 동안 유효하다.',
+        '- 프론트 화면: [화면 (Figma)](https://www.figma.com/design/AtU0tCeeJ6GKP0M7X3fFO0/%EB%8B%A4%EC%9D%B4%EB%85%B8%EC%8A%A4-%EA%B0%9C%EB%B0%9C?node-id=201-5941&t=zRtKYhIbdF799Dtl-0)',
+      ].join('\n'),
     }),
     ApiBody({
       type: CreatePresignedUrlDto,
@@ -231,13 +238,14 @@ export const GetBulkPresignedUrlDocs = () => {
   return applyDecorators(
     ApiOperation({
       summary: '다중 presigned url 발급',
-      description: `
-      - 다중 presigned url 발급을 요청한다.
-      - 최대로 요청 할 수 있는 값은 10개로 제한된다.
-      - 요청을 보낼 때, DTO 요청값 (filename, size, mimeType)은 원본 파일과 동일한 정보를 기반으로 요청을 보내야 한다. (요청 받은 이미지의 메타 정보와 불일치할 경우 업로드 실패)
-      - 발급된 presigned url은 프론트에서 이용 가능하며, 업로드 완료 후 경로값을 백단으로 보내기 위한 cdn url도 함께 발급된다.
-      - 발급된 presigned url은 1시간 동안 유효하다.
-      `,
+      description: [
+        '- 다중 presigned url 발급을 요청한다.',
+        '- 최대로 요청 할 수 있는 값은 10개로 제한된다.',
+        '- 요청을 보낼 때, DTO 요청값 (filename, size, mimeType)은 원본 파일과 동일한 정보를 기반으로 요청을 보내야 한다. (요청 받은 이미지의 메타 정보와 불일치할 경우 업로드 실패)',
+        '- 발급된 presigned url은 프론트에서 이용 가능하며, 업로드 완료 후 경로값을 백단으로 보내기 위한 cdn url도 함께 발급된다.',
+        '- 발급된 presigned url은 1시간 동안 유효하다.',
+        '- 프론트 화면: [화면 (Figma)](https://www.figma.com/design/AtU0tCeeJ6GKP0M7X3fFO0/%EB%8B%A4%EC%9D%B4%EB%85%B8%EC%8A%A4-%EA%B0%9C%EB%B0%9C?node-id=201-5941&t=zRtKYhIbdF799Dtl-0)',
+      ].join('\n'),
     }),
     ApiBody({
       type: CreateBulkPresignedUrlDto,
@@ -265,11 +273,11 @@ export const CreateReviewQuestionDocs = () => {
   return applyDecorators(
     ApiOperation({
       summary: '리뷰 질문 생성 (관리자용)',
-      description: `
-      - 리뷰 질문을 생성한다.
-      - 질문과 선택지를 함께 생성한다.
-      - step은 BEFORE_ENTRY, ENTRY, ORDER, MEAL, WRAP_UP 중 하나를 선택한다.
-      `,
+      description: [
+        '- 리뷰 질문을 생성한다.',
+        '- 질문과 선택지를 함께 생성한다.',
+        '- step은 BEFORE_ENTRY, ENTRY, ORDER, MEAL, WRAP_UP 중 하나를 선택한다.',
+      ].join('\n'),
     }),
     ApiBody({
       type: CreateReviewQuestionDto,
@@ -296,11 +304,11 @@ export const CreateReviewQuestionsBulkDocs = () => {
   return applyDecorators(
     ApiOperation({
       summary: '리뷰 질문 일괄 생성 (관리자용)',
-      description: `
-      - 여러 리뷰의 질문 리스트를 한 번에 생성한다.
-      - 각 질문과 선택지를 함께 생성한다.
-      - 개수 제한 없이 원하는 만큼 질문을 생성할 수 있다.
-      `,
+      description: [
+        '- 여러 리뷰의 질문 리스트를 한 번에 생성한다.',
+        '- 각 질문과 선택지를 함께 생성한다.',
+        '- 개수 제한 없이 원하는 만큼 질문을 생성할 수 있다.',
+      ].join('\n'),
     }),
     ApiBody({
       type: CreateReviewQuestionsBulkDto,

--- a/src/user/presentation/swagger/rest-swagger.decorator.ts
+++ b/src/user/presentation/swagger/rest-swagger.decorator.ts
@@ -18,10 +18,11 @@ export const WithdrawUserDocs = () => {
   return applyDecorators(
     ApiOperation({
       summary: '회원탈퇴',
-      description: `
-        - 유저를 회원탈퇴 시킨다. 
-        - 유저와 연관된 데이터를 모두 제거한다. 
-        `,
+      description: [
+        '- 유저를 회원탈퇴 시킨다.',
+        '- 유저와 연관된 데이터를 모두 제거한다.',
+        '- 프론트 화면: [화면 (Figma)](https://www.figma.com/design/AtU0tCeeJ6GKP0M7X3fFO0/%EB%8B%A4%EC%9D%B4%EB%85%B8%EC%8A%A4-%EA%B0%9C%EB%B0%9C?node-id=201-7069&t=zRtKYhIbdF799Dtl-0)',
+      ].join('\n'),
     }),
     ApiNoContentResponseTemplate({
       description: '회원탈퇴 성공',
@@ -40,10 +41,11 @@ export const FindByProfileWithInviteInfoDocs = () => {
   return applyDecorators(
     ApiOperation({
       summary: `유저의 프로필 정보 및 초대코드 & 친구 요청수 & 나의 친구수 & 작성한 리뷰수 일괄조회 `,
-      description: `
-        - token에 담긴 userId 값을 기반으로 유저 프로필 정보 조회
-        - userId 값을 base로 사용자의 프로필 정보, 초대코드, 친구 요청건수, 나의 친구수, 작성한 리뷰수를 일괄로 조회한다.
-        `,
+      description: [
+        '- token에 담긴 userId 값을 기반으로 유저 프로필 정보 조회',
+        '- userId 값을 base로 사용자의 프로필 정보, 초대코드, 친구 요청건수, 나의 친구수, 작성한 리뷰수를 일괄로 조회한다.',
+        '- 프론트 화면: [화면 조정 필요 (Figma)](https://www.figma.com/design/AtU0tCeeJ6GKP0M7X3fFO0/%EB%8B%A4%EC%9D%B4%EB%85%B8%EC%8A%A4-%EA%B0%9C%EB%B0%9C?node-id=201-6565&t=zRtKYhIbdF799Dtl-0)',
+      ].join('\n'),
     }),
     ApiOkResponseTemplate({
       description: '유저의 프로필 정보 및 초대코드 & 친구 요청수 조회 성공',
@@ -67,10 +69,11 @@ export const CreateUserProfileDocs = () => {
   return applyDecorators(
     ApiOperation({
       summary: '유저 프로필 생성',
-      description: `
-        - 유저 프로필을 생성한다.
-        - 유저 프로필 생성시, nickname은 필수값이고, 나머지 항목은 선택적으로 요청을 보내야한다.
-        `,
+      description: [
+        '- 유저 프로필을 생성한다.',
+        '- 유저 프로필 생성시, nickname은 필수값이고, 나머지 항목은 선택적으로 요청을 보내야한다.',
+        '- 유저 프로필은 계정 생성시 디폴트로 생성되기 때문에 별도로 화면 연결은 없음. patch를 사용',
+      ].join('\n'),
     }),
     ApiBody({
       type: CreateUserProfileDto,
@@ -97,11 +100,12 @@ export const UpdateUserProfileDocs = () => {
   return applyDecorators(
     ApiOperation({
       summary: '유저 프로필 수정',
-      description: `
-        - 유저 프로필을 수정한다.
-        - Bearer AccessToken의 userId를 기반으로 프로필을 조회하여 수정한다.
-        - 유저 프로필 수정시, nickname은 필수값이고, 나머지 항목은 선택적으로 요청을 보내야한다.
-        `,
+      description: [
+        '- 유저 프로필을 수정한다.',
+        '- Bearer AccessToken의 userId를 기반으로 프로필을 조회하여 수정한다.',
+        '- 유저 프로필 수정시, nickname은 필수값이고, 나머지 항목은 선택적으로 요청을 보내야한다.',
+        '- 프론트 화면: [화면 (Figma)](https://www.figma.com/design/AtU0tCeeJ6GKP0M7X3fFO0/%EB%8B%A4%EC%9D%B4%EB%85%B8%EC%8A%A4-%EA%B0%9C%EB%B0%9C?node-id=201-6441&t=zRtKYhIbdF799Dtl-0)',
+      ].join('\n'),
     }),
     ApiBody({
       type: UpdateUserProfileDto,
@@ -124,10 +128,11 @@ export const FindByInviteCodeDocs = () => {
   return applyDecorators(
     ApiOperation({
       summary: '초대코드 기반 유저정보 조회',
-      description: `
-      - 최초가입시 유저별로 할당되는 초대코드를 기반으로 유저의 기본정보를 조회한다. 
-      - 가입시, name(이름)은 nullable 하기 때문에, name으로 화면에 표기할지, nickname을 표기할지는 별도로 논의가 필요함.
-      `,
+      description: [
+        '- 최초가입시 유저별로 할당되는 초대코드를 기반으로 유저의 기본정보를 조회한다.',
+        '- 가입시, name(이름)은 nullable 하기 때문에, name으로 화면에 표기할지, nickname을 표기할지는 별도로 논의가 필요함.',
+        '- 프론트 화면: [화면 (Figma)](https://www.figma.com/design/AtU0tCeeJ6GKP0M7X3fFO0/%EB%8B%A4%EC%9D%B4%EB%85%B8%EC%8A%A4-%EA%B0%9C%EB%B0%9C?node-id=201-6909&t=zRtKYhIbdF799Dtl-0)',
+      ].join('\n'),
     }),
     ApiOkResponseTemplate({
       description: '초대코드 기반 유저 조회 성공',


### PR DESCRIPTION
## #️⃣연관된 이슈

> #130

## 📝작업 내용
- 전 도메인 ApiOperation description을 배열 + join('\n') 방식으로 통일 (들여쓰기로 인한 마크다운 코드블록 렌더 이슈 제거)
- 각 엔드포인트 description에 대응 화면 Figma 링크 추가 (프론트 연동 가이드)
- bookmark / feed 컨트롤러 ApiTags에 Deprecated(미사용 api) 표기